### PR TITLE
fix(next15): replace React.use with async/await for params & guard client-only

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -3,8 +3,13 @@ import { NextIntlClientProvider } from 'next-intl';
 import { notFound } from 'next/navigation';
 import { ReactNode } from 'react';
 import { unstable_setRequestLocale } from 'next-intl/server';
+import { Plus_Jakarta_Sans } from 'next/font/google';
+import { cn } from '../../lib/utils';
+import { ToasterClient } from '../../components/ToasterClient';
 import { isValidLocale, locales } from '../../lib/i18n';
 import { FooterNoSSR, NavbarNoSSR } from '../../src/components/no-ssr';
+
+const jakarta = Plus_Jakarta_Sans({ subsets: ['latin'], variable: '--font-sans', display: 'swap' });
 
 export const dynamic = 'force-dynamic';
 
@@ -35,12 +40,22 @@ export default async function LocaleLayout({
   const messages = await import(`../../messages/${locale}.json`).then((mod) => mod.default);
 
   return (
-    <NextIntlClientProvider locale={locale} messages={messages}>
-      <div className="flex min-h-dvh flex-col" data-locale={locale}>
-        <NavbarNoSSR locale={locale} showSections={false} />
-        <main className="container flex-1 pb-24 pt-28">{children}</main>
-        <FooterNoSSR />
-      </div>
-    </NextIntlClientProvider>
+    <html lang={locale} className="dark" suppressHydrationWarning>
+      <body
+        className={cn(
+          'min-h-dvh bg-background text-foreground font-sans antialiased',
+          jakarta.variable
+        )}
+      >
+        <NextIntlClientProvider locale={locale} messages={messages}>
+          <div className="flex min-h-dvh flex-col" data-locale={locale}>
+            <NavbarNoSSR locale={locale} showSections={false} />
+            <main className="container flex-1 pb-24 pt-28">{children}</main>
+            <FooterNoSSR />
+          </div>
+          <ToasterClient />
+        </NextIntlClientProvider>
+      </body>
+    </html>
   );
 }

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -1,14 +1,17 @@
 import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
-import { use } from 'react';
-import HeroInteractiveImage from '../../src/components/HeroInteractiveImage';
-import { BeforeAfterNoSSR, FeatureGridNoSSR, PricingSectionNoSSR } from '../../src/components/no-ssr';
+import {
+  BeforeAfterNoSSR,
+  FeatureGridNoSSR,
+  HeroInteractiveImageNoSSR,
+  PricingSectionNoSSR
+} from '../../src/components/no-ssr';
 import { SectionHeading } from '../../src/components/SectionHeading';
 import { Button } from '../../src/components/ui/button';
 
 export default async function LocaleLanding({ params }: { params: Promise<{ locale: string }> }) {
-  const { locale } = use(params);
+  const { locale } = await params;
   const t = await getTranslations({ locale, namespace: 'common' });
 
   return (
@@ -35,7 +38,7 @@ export default async function LocaleLanding({ params }: { params: Promise<{ loca
             </p>
           </div>
         </div>
-        <HeroInteractiveImage
+        <HeroInteractiveImageNoSSR
           src="https://images.unsplash.com/photo-1521986329282-0436c1b74404?auto=format&fit=crop&w=1600&q=80"
           className="w-full max-w-[720px] ml-auto"
         />

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,14 +1,8 @@
 import type { Metadata } from 'next';
-import { Plus_Jakarta_Sans } from 'next/font/google';
-import { use } from 'react';
 import '../styles/globals.css';
 import 'sonner/dist/styles.css';
-import { cn } from '../lib/utils';
-import { ToasterClient } from '../components/ToasterClient';
 
 export const dynamic = 'force-dynamic';
-
-const jakarta = Plus_Jakarta_Sans({ subsets: ['latin'], variable: '--font-sans', display: 'swap' });
 
 export const metadata: Metadata = {
   title: 'UMKM Kits Studio',
@@ -16,21 +10,9 @@ export const metadata: Metadata = {
 };
 
 export default function RootLayout({
-  children,
-  params
+  children
 }: {
   children: React.ReactNode;
-  params: Promise<{ locale?: string }>;
 }) {
-  const resolvedParams = use(params);
-  const locale = resolvedParams?.locale ?? 'id';
-
-  return (
-    <html lang={locale} className={cn('dark', jakarta.variable)} suppressHydrationWarning>
-      <body className="min-h-dvh bg-background text-foreground font-sans antialiased">
-        {children}
-        <ToasterClient />
-      </body>
-    </html>
-  );
+  return children;
 }

--- a/apps/web/src/components/no-ssr.tsx
+++ b/apps/web/src/components/no-ssr.tsx
@@ -8,6 +8,7 @@ type FooterComponent = typeof import('./Footer')['Footer'];
 type FeatureGridComponent = typeof import('./FeatureGrid')['FeatureGrid'];
 type BeforeAfterComponent = typeof import('./BeforeAfter')['BeforeAfter'];
 type PricingSectionComponent = typeof import('./PricingSection')['PricingSection'];
+type HeroInteractiveImageComponent = typeof import('./HeroInteractiveImage')['default'];
 
 export const NavbarNoSSR = dynamic<ComponentProps<NavbarComponent>>(
   () => import('./Navbar').then((mod) => mod.Navbar),
@@ -31,5 +32,10 @@ export const BeforeAfterNoSSR = dynamic<ComponentProps<BeforeAfterComponent>>(
 
 export const PricingSectionNoSSR = dynamic<ComponentProps<PricingSectionComponent>>(
   () => import('./PricingSection').then((mod) => mod.PricingSection),
+  { ssr: false }
+);
+
+export const HeroInteractiveImageNoSSR = dynamic<ComponentProps<HeroInteractiveImageComponent>>(
+  () => import('./HeroInteractiveImage'),
   { ssr: false }
 );


### PR DESCRIPTION
## Summary
- migrate app layouts and pages to await `params` directly instead of calling `React.use`
- move document shell into the locale layout so the `<html>` tag is derived from the awaited locale and render the toaster/font styles from there
- ensure interactive hero media is loaded through an SSR-disabled dynamic wrapper alongside other no-SSR helpers

## Testing
- pnpm --filter web build

------
https://chatgpt.com/codex/tasks/task_e_68d8b623f3748327bf021eab78d1c43c