### PR TITLE
Fix font hydration mismatch and add loading skeletons

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,6 +1,13 @@
 import type { Metadata } from "next";
+import { Plus_Jakarta_Sans } from "next/font/google";
 import "../styles/globals.css";
 import "sonner/dist/styles.css";
+
+const fontSans = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "UMKM Kits Studio",
@@ -17,7 +24,9 @@ export default function RootLayout({
 }) {
   return (
     <html lang="id" className="dark" suppressHydrationWarning>
-      <body className="min-h-dvh bg-background text-foreground">
+      <body
+        className={`min-h-dvh bg-background text-foreground antialiased font-sans ${fontSans.variable}`}
+      >
         {children}
       </body>
     </html>

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -4,7 +4,15 @@ import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { ArrowRight } from 'lucide-react';
 import { BeforeAfterNoSSR, FeatureGridNoSSR, FooterNoSSR, NavbarNoSSR, PricingSectionNoSSR } from '../src/components/no-ssr';
-const HeroInteractiveImage = dynamic(() => import('../src/components/HeroInteractiveImage'), { ssr: false });
+const HeroInteractiveImage = dynamic(
+  () => import('../src/components/HeroInteractiveImage'),
+  {
+    ssr: false,
+    loading: () => (
+      <div className="aspect-[5/3] rounded-2xl bg-secondary/30 animate-pulse" />
+    ),
+  }
+);
 import { SectionHeading } from '../src/components/SectionHeading';
 import { Button } from '../src/components/ui/button';
 import { defaultLocale } from '../lib/i18n';

--- a/apps/web/src/components/no-ssr.tsx
+++ b/apps/web/src/components/no-ssr.tsx
@@ -22,20 +22,40 @@ export const FooterNoSSR = dynamic<ComponentProps<FooterComponent>>(
 
 export const FeatureGridNoSSR = dynamic<ComponentProps<FeatureGridComponent>>(
   () => import('./FeatureGrid').then((mod) => mod.FeatureGrid),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => (
+      <div className="aspect-[5/3] rounded-2xl bg-secondary/30 animate-pulse" />
+    ),
+  }
 );
 
 export const BeforeAfterNoSSR = dynamic<ComponentProps<BeforeAfterComponent>>(
   () => import('./BeforeAfter').then((mod) => mod.BeforeAfter),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => (
+      <div className="aspect-[5/3] rounded-2xl bg-secondary/30 animate-pulse" />
+    ),
+  }
 );
 
 export const PricingSectionNoSSR = dynamic<ComponentProps<PricingSectionComponent>>(
   () => import('./PricingSection').then((mod) => mod.PricingSection),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => (
+      <div className="aspect-[5/3] rounded-2xl bg-secondary/30 animate-pulse" />
+    ),
+  }
 );
 
 export const HeroInteractiveImageNoSSR = dynamic<ComponentProps<HeroInteractiveImageComponent>>(
   () => import('./HeroInteractiveImage'),
-  { ssr: false }
+  {
+    ssr: false,
+    loading: () => (
+      <div className="aspect-[5/3] rounded-2xl bg-secondary/30 animate-pulse" />
+    ),
+  }
 );

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -32,6 +32,7 @@ const config: Config = {
           DEFAULT: '#0F172A',
           light: '#F8FAFC'
         },
+        secondary: '#1E293B',
         text: {
           DEFAULT: '#E2E8F0',
           dark: '#0F172A'
@@ -52,7 +53,7 @@ const config: Config = {
         }
       },
       fontFamily: {
-        sans: ['"Plus Jakarta Sans"', ...defaultTheme.fontFamily.sans],
+        sans: ['var(--font-sans)', ...defaultTheme.fontFamily.sans],
         display: ['"Clash Display"', ...defaultTheme.fontFamily.sans]
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- load Plus Jakarta Sans via next/font and wire the CSS variable into the root layout classes to eliminate hydration class mismatches
- ensure Tailwind uses the font variable, define a secondary color token, and add consistent skeleton fallbacks for dynamic marketing components
- provide a loading placeholder for the hero image import so interactive media renders safely without SSR

## Testing
- CI=1 pnpm build:web

------
https://chatgpt.com/codex/tasks/task_e_68d8c3c622d0832794e3daf52f726876