### PR TITLE
Fix hero spacing under navbar

### DIFF
--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -16,32 +16,39 @@ export default async function LocaleLanding({ params }: { params: Promise<{ loca
 
   return (
     <div className="space-y-28">
-      <section id="hero" className="grid items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
-        <div className="space-y-8">
-          <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
-            {locale === 'id' ? 'Studio AI untuk UMKM' : 'AI Studio for F&B brands'}
-          </span>
-          <h1 className="font-display text-4xl leading-tight text-white md:text-6xl">{t('heroTitle')}</h1>
-          <p className="max-w-xl text-lg text-[var(--text-muted)]">{t('heroSubtitle')}</p>
-          <div className="flex flex-wrap items-center gap-4">
-            <Button size="lg" asChild>
-              <Link href={`/${locale}/sign-up`}>{t('cta')}</Link>
-            </Button>
-            <Button size="lg" variant="secondary" asChild>
-              <Link href={`/${locale}/editor`}>
-                {locale === 'id' ? 'Buka Editor' : 'Open Editor'}
-                <ArrowRight className="ml-2 h-4 w-4" />
-              </Link>
-            </Button>
-            <p className="text-sm text-[var(--text-muted)]">
-              {locale === 'id' ? 'Tanpa kartu kredit • Demo gratis 3 menit' : 'No credit card • Try the 3-minute demo'}
-            </p>
+      <section
+        id="home"
+        className="scroll-mt-[calc(var(--nav-h)+12px)] pt-6 md:pt-10 lg:pt-12"
+      >
+        <div className="container mx-auto">
+          <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
+            <div className="space-y-8">
+              <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
+                {locale === 'id' ? 'Studio AI untuk UMKM' : 'AI Studio for F&B brands'}
+              </span>
+              <h1 className="font-display text-4xl leading-tight text-white md:text-6xl">{t('heroTitle')}</h1>
+              <p className="max-w-xl text-lg text-[var(--text-muted)]">{t('heroSubtitle')}</p>
+              <div className="flex flex-wrap items-center gap-4">
+                <Button size="lg" asChild>
+                  <Link href={`/${locale}/sign-up`}>{t('cta')}</Link>
+                </Button>
+                <Button size="lg" variant="secondary" asChild>
+                  <Link href={`/${locale}/editor`}>
+                    {locale === 'id' ? 'Buka Editor' : 'Open Editor'}
+                    <ArrowRight className="ml-2 h-4 w-4" />
+                  </Link>
+                </Button>
+                <p className="text-sm text-[var(--text-muted)]">
+                  {locale === 'id' ? 'Tanpa kartu kredit • Demo gratis 3 menit' : 'No credit card • Try the 3-minute demo'}
+                </p>
+              </div>
+            </div>
+            <HeroInteractiveImageNoSSR
+              src="https://images.unsplash.com/photo-1521986329282-0436c1b74404?auto=format&fit=crop&w=1600&q=80"
+              className="ml-auto w-full max-w-[720px]"
+            />
           </div>
         </div>
-        <HeroInteractiveImageNoSSR
-          src="https://images.unsplash.com/photo-1521986329282-0436c1b74404?auto=format&fit=crop&w=1600&q=80"
-          className="w-full max-w-[720px] ml-auto"
-        />
       </section>
 
       <section id="features" className="space-y-12">

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -27,7 +27,7 @@ export default function RootLayout({
       <body
         className={`min-h-dvh bg-background text-foreground antialiased font-sans ${fontSans.variable}`}
       >
-        {children}
+        <main className="pt-[var(--nav-h)]">{children}</main>
       </body>
     </html>
   );

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -23,36 +23,43 @@ export default function MarketingPage() {
   return (
     <div className="relative min-h-screen overflow-hidden bg-background text-white">
       <NavbarNoSSR locale={locale} showSections />
-      <main className="relative pt-28">
+      <main className="relative">
         <div className="pointer-events-none absolute inset-0 -z-10 bg-radial-hero" aria-hidden />
-        <section id="hero" className="container grid items-center gap-12 pb-28 lg:grid-cols-[1.05fr_0.95fr]">
-          <div className="space-y-8">
-            <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
-              Studio AI untuk UMKM
-            </span>
-            <h1 className="max-w-xl font-display text-4xl leading-tight text-white md:text-6xl">
-              Visual interaktif & caption AI untuk scale up brand kuliner Anda
-            </h1>
-            <p className="max-w-xl text-lg text-[var(--text-muted)]">
-              Bangun storytelling makanan yang menggugah selera, tingkatkan engagement, dan kelola tim konten dari satu studio modern dengan aksen biru kosmik.
-            </p>
-            <div className="flex flex-wrap items-center gap-4">
-              <Button size="lg" asChild>
-                <Link href={`/${locale}/sign-up`}>Coba Gratis Sekarang</Link>
-              </Button>
-              <Button size="lg" variant="secondary" asChild>
-                <Link href="#editor-demo">
-                  Lihat Editor
-                  <ArrowRight className="ml-2 h-4 w-4" />
-                </Link>
-              </Button>
-              <p className="text-sm text-[var(--text-muted)]">Tidak perlu kartu kredit • 3 menit onboarding</p>
+        <section
+          id="home"
+          className="scroll-mt-[calc(var(--nav-h)+12px)] pt-6 md:pt-10 lg:pt-12 pb-28"
+        >
+          <div className="container mx-auto">
+            <div className="grid grid-cols-1 items-center gap-12 lg:grid-cols-[1.05fr_0.95fr]">
+              <div className="space-y-8">
+                <span className="inline-flex w-fit items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.3em] text-primary">
+                  Studio AI untuk UMKM
+                </span>
+                <h1 className="max-w-xl font-display text-4xl leading-tight text-white md:text-6xl">
+                  Visual interaktif & caption AI untuk scale up brand kuliner Anda
+                </h1>
+                <p className="max-w-xl text-lg text-[var(--text-muted)]">
+                  Bangun storytelling makanan yang menggugah selera, tingkatkan engagement, dan kelola tim konten dari satu studio modern dengan aksen biru kosmik.
+                </p>
+                <div className="flex flex-wrap items-center gap-4">
+                  <Button size="lg" asChild>
+                    <Link href={`/${locale}/sign-up`}>Coba Gratis Sekarang</Link>
+                  </Button>
+                  <Button size="lg" variant="secondary" asChild>
+                    <Link href="#editor-demo">
+                      Lihat Editor
+                      <ArrowRight className="ml-2 h-4 w-4" />
+                    </Link>
+                  </Button>
+                  <p className="text-sm text-[var(--text-muted)]">Tidak perlu kartu kredit • 3 menit onboarding</p>
+                </div>
+              </div>
+              <HeroInteractiveImage
+                src="https://images.unsplash.com/photo-1521986329282-0436c1b74404?auto=format&fit=crop&w=1600&q=80"
+                className="ml-auto w-full max-w-[720px]"
+              />
             </div>
           </div>
-          <HeroInteractiveImage
-            src="https://images.unsplash.com/photo-1521986329282-0436c1b74404?auto=format&fit=crop&w=1600&q=80"
-            className="w-full max-w-[720px] ml-auto"
-          />
         </section>
 
         <section id="features" className="container space-y-12 pb-28">

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
 import { Menu, Sparkles } from 'lucide-react';
 import { motion, useScroll } from 'framer-motion';
@@ -11,7 +11,7 @@ import { LangToggle } from '../../components/lang-toggle';
 import { cn } from '../../lib/utils';
 
 const NAV_SECTIONS = [
-  { id: 'hero', label: 'Beranda' },
+  { id: 'home', label: 'Beranda' },
   { id: 'features', label: 'Fitur' },
   { id: 'gallery', label: 'Galeri' },
   { id: 'pricing', label: 'Harga' }
@@ -19,7 +19,9 @@ const NAV_SECTIONS = [
 
 export function Navbar({ locale = 'id', showSections = true }: { locale?: string; showSections?: boolean }) {
   const pathname = usePathname();
-  const [active, setActive] = useState('hero');
+  const params = useParams<{ locale?: string }>();
+  const base = params?.locale ? `/${params.locale}` : '';
+  const [active, setActive] = useState('home');
   const [isSheetOpen, setSheetOpen] = useState(false);
   const { scrollY } = useScroll();
   const [scrolled, setScrolled] = useState(false);
@@ -73,9 +75,9 @@ export function Navbar({ locale = 'id', showSections = true }: { locale?: string
         {showSections ? (
           <nav className="hidden items-center gap-6 text-sm font-medium md:flex">
             {navItems.map((item) => (
-              <a
+              <Link
                 key={item.id}
-                href={`#${item.id}`}
+                href={`${base}/#${item.id}`}
                 className={cn(
                   'relative px-2 py-1 text-[var(--text-muted)] transition-colors hover:text-white',
                   active === item.id && 'text-white'
@@ -89,7 +91,7 @@ export function Navbar({ locale = 'id', showSections = true }: { locale?: string
                   />
                 )}
                 {item.label}
-              </a>
+              </Link>
             ))}
           </nav>
         ) : (
@@ -129,7 +131,7 @@ export function Navbar({ locale = 'id', showSections = true }: { locale?: string
                         onClick={() => setSheetOpen(false)}
                         asChild
                       >
-                        <Link href={`#${item.id}` as never}>{item.label}</Link>
+                        <Link href={`${base}/#${item.id}`}>{item.label}</Link>
                       </Button>
                     ))
                   : null}

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -78,7 +78,7 @@ export function Navbar({ locale = "id" }: { locale?: Locale }) {
     >
       <div className="container flex h-full items-center justify-between gap-4">
         <Link
-          href={brandHref}
+          href={{ pathname: basePath, hash: item.id }}
           className="flex items-center gap-2 text-sm font-semibold tracking-tight"
         >
           <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-accent text-white shadow-lg shadow-blue-600/40">
@@ -140,7 +140,7 @@ export function Navbar({ locale = "id" }: { locale?: Locale }) {
                         asChild
                       >
 
-                        <Link href={`${base}/#${item.id}`}>{item.label}</Link>
+                        <Link href={{ pathname: basePath, hash: item.id }}>{item.label}</Link>
 
                       </Button>
                     ))

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -17,10 +17,10 @@ const NAV_SECTIONS = [
   { id: 'gallery', label: 'Galeri' },
   { id: 'pricing', label: 'Harga' }
 
-];
+] as const;
 
 export function Navbar({ locale = "id" }: { locale?: Locale }) {
-  const params = (useParams<{ locale?: string }>() ?? {}) as { locale?: string };
+  const basePath: `/${string}` | '/' = params?.locale ? `/${params.locale}` : '/'
   const pathname = usePathname();
 
   const params = useParams<{ locale?: string }>();

--- a/apps/web/styles/globals.css
+++ b/apps/web/styles/globals.css
@@ -4,6 +4,7 @@
 
 :root {
   color-scheme: dark;
+  --nav-h: 64px;
   --background: #0b0f1a;
   --surface: #0f172a;
   --text-primary: #e2e8f0;
@@ -13,6 +14,15 @@
   --radius-xl: 1rem;
   --radius-2xl: 1.5rem;
   --shadow-soft: 0 30px 80px -40px rgba(59, 130, 246, 0.45);
+}
+
+@media (min-width: 1024px) {
+  :root {
+    --nav-h: 80px;
+  }
+}
+
+html {
   scroll-behavior: smooth;
 }
 
@@ -27,7 +37,7 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  :root {
+  html {
     scroll-behavior: auto;
   }
 }

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -14,9 +14,12 @@ const config: Config = {
     container: {
       center: true,
       padding: {
-        DEFAULT: '1.5rem',
-        sm: '2rem',
-        lg: '2.5rem'
+        DEFAULT: '1rem',
+        sm: '1.25rem',
+        md: '1.5rem',
+        lg: '2rem',
+        xl: '3rem',
+        '2xl': '4rem'
       },
       screens: {
         '2xl': '80rem'
@@ -53,7 +56,7 @@ const config: Config = {
         }
       },
       fontFamily: {
-        sans: ['var(--font-sans)', ...defaultTheme.fontFamily.sans],
+        sans: ['var(--font-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
         display: ['"Clash Display"', ...defaultTheme.fontFamily.sans]
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- add CSS variables and Tailwind container padding defaults to keep marketing containers away from the viewport edge
- offset the root layout and hero sections so the Beranda section clears the navbar and gains breathing room
- retarget navbar anchors to the new hero id across default and localized marketing pages

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8d93be68c8327a8a0c131d09356db