### PR TITLE
Improve Firebase env handling and developer guidance

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,0 +1,10 @@
+# 🔐 Client-side (harus berawalan NEXT_PUBLIC_)
+NEXT_PUBLIC_FIREBASE_API_KEY=
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=<project>.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=<project-id>
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET=<project-id>.appspot.com
+NEXT_PUBLIC_FIREBASE_APP_ID=
+
+# opsional
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID=
+NEXT_PUBLIC_API_BASE=https://asia-southeast2-<project-id>.cloudfunctions.net/api

--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -3,37 +3,85 @@
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useTranslations } from 'next-intl';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Button } from '../../../components/ui/button';
 import { Input } from '../../../components/ui/input';
 import { CardX, CardXFooter, CardXHeader } from '../../../components/ui/cardx';
 import { getFirebaseAuth } from '../../../lib/firebase-client';
 
+async function readEnvFlags(): Promise<string[]> {
+  try {
+    const res = await fetch('/api/env-check', { cache: 'no-store' });
+    const json = await res.json();
+    const missing: string[] = [];
+    if (!json?.flags?.API_KEY) missing.push('NEXT_PUBLIC_FIREBASE_API_KEY');
+    if (!json?.flags?.AUTH_DOMAIN) missing.push('NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN');
+    if (!json?.flags?.PROJECT_ID) missing.push('NEXT_PUBLIC_FIREBASE_PROJECT_ID');
+    if (!json?.flags?.STORAGE_BUCKET) missing.push('NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET');
+    if (!json?.flags?.APP_ID) missing.push('NEXT_PUBLIC_FIREBASE_APP_ID');
+    return missing;
+  } catch {
+    return [];
+  }
+}
+
 export default function SignUpPage() {
   const { locale } = useParams<{ locale: string }>();
   const t = useTranslations('auth');
+  const auth = getFirebaseAuth();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [missing, setMissing] = useState<string[] | null>(null);
+
+  useEffect(() => {
+    if (!auth) {
+      readEnvFlags().then(setMissing);
+    }
+  }, [auth]);
+
+  if (!auth) {
+    return (
+      <div className="container max-w-lg mx-auto py-16">
+        <h1 className="text-xl font-semibold mb-2">Konfigurasi Firebase belum lengkap</h1>
+        <p className="text-sm text-muted-foreground">
+          Pastikan variable berikut diisi di Vercel (Production/Preview) atau <code>.env.local</code> pada <code>apps/web/</code>,{' '}
+          lalu redeploy/jalankan ulang:
+        </p>
+        <ul className="mt-3 list-disc list-inside text-sm">
+          {(missing ?? []).map((key) => (
+            <li key={key}>
+              <code>{key}</code>
+            </li>
+          ))}
+        </ul>
+        <p className="mt-3 text-xs text-muted-foreground">
+          Cek cepat: <a className="underline" href="/api/env-check" target="_blank" rel="noreferrer">/api/env-check</a>
+        </p>
+      </div>
+    );
+  }
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const auth = getFirebaseAuth();
-    if (!auth) {
+    const currentAuth = getFirebaseAuth();
+    if (!currentAuth) {
       setError('Konfigurasi Firebase belum lengkap.');
       return;
     }
     setLoading(true);
     try {
       const { createUserWithEmailAndPassword } = await import('firebase/auth');
-      await createUserWithEmailAndPassword(auth, email, password);
+      await createUserWithEmailAndPassword(currentAuth, email, password);
     } catch (err: unknown) {
       setError(err instanceof Error ? err.message : 'Gagal mendaftar.');
     } finally {
       setLoading(false);
     }
   };
+
+  const disabled = loading || !auth;
 
   return (
     <div className="container mx-auto max-w-lg py-16">
@@ -70,7 +118,7 @@ export default function SignUpPage() {
             />
           </div>
           {error ? <p className="text-sm text-destructive">{error}</p> : null}
-          <Button type="submit" className="w-full" disabled={loading}>
+          <Button type="submit" className="w-full" disabled={disabled}>
             {loading ? 'Memproses...' : t('signUp')}
           </Button>
         </form>

--- a/apps/web/app/api/env-check/route.ts
+++ b/apps/web/app/api/env-check/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+
+export function GET() {
+  return NextResponse.json({
+    ok: true,
+    flags: {
+      API_KEY: !!process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+      AUTH_DOMAIN: !!process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+      PROJECT_ID: !!process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+      STORAGE_BUCKET: !!process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+      APP_ID: !!process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+      MEASUREMENT_ID: !!process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID // opsional
+    },
+    // hint tidak mengandung nilai rahasia
+    hints: {
+      storageBucketShouldEndWith: '.appspot.com',
+      commonMistake: 'Jangan pakai URL firebasestorage…; gunakan <project-id>.appspot.com'
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- strengthen the firebase client helper with explicit missing-key detection and local auth persistence
- add a safe /api/env-check endpoint for debugging public firebase config flags
- show missing firebase env keys on sign-in and sign-up pages and document expected NEXT_PUBLIC_ variables

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8fb1a55488327b768393ffbfd1462