### PR TITLE
fix: stabilize root layout font and navigation spacing

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,5 +1,8 @@
 import type { Metadata } from "next";
 import { Plus_Jakarta_Sans } from "next/font/google";
+import type { ReactNode } from "react";
+
+import { cn } from "../lib/utils";
 import "../styles/globals.css";
 import "sonner/dist/styles.css";
 
@@ -17,16 +20,14 @@ export const metadata: Metadata = {
 // (opsional) kalau tidak butuh, hapus baris dynamic di bawah
 // export const dynamic = "force-dynamic";
 
-export default function RootLayout({
-  children,
-}: {
-  children: React.ReactNode;
-}) {
+export default function RootLayout({ children }: { children: ReactNode }) {
   return (
-    <html lang="id" className="dark" suppressHydrationWarning>
-      <body
-        className={`min-h-dvh bg-background text-foreground antialiased font-sans ${fontSans.variable}`}
-      >
+    <html
+      lang="id"
+      suppressHydrationWarning
+      className={cn("dark", fontSans.variable)}
+    >
+      <body className="min-h-dvh bg-background text-foreground antialiased font-sans">
         <main className="pt-[var(--nav-h)]">{children}</main>
       </body>
     </html>

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -56,7 +56,7 @@ const config: Config = {
         }
       },
       fontFamily: {
-        sans: ['var(--font-sans)', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        sans: ['var(--font-sans)', ...defaultTheme.fontFamily.sans],
         display: ['"Clash Display"', ...defaultTheme.fontFamily.sans]
       },
       borderRadius: {


### PR DESCRIPTION
## Summary
- ensure the Next.js root layout wraps children with `<html>`/`<body>`, applies the Plus Jakarta Sans SSR font variable, and offsets page content by the navbar height
- import the shared `cn` helper for layout class composition and keep Tailwind's sans stack in sync with the CSS variable via the default theme fallback

## Testing
- CI=1 pnpm web:build
- CI=1 pnpm web:snap *(fails: Next.js image optimizer cannot fetch remote assets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d92291cd608327b434d80c65d9ecb3