### PR TITLE
fix(firebase): static env reads + /api/env-check + clearer auth UX

### DIFF
--- a/apps/web/app/[locale]/sign-in/page.tsx
+++ b/apps/web/app/[locale]/sign-in/page.tsx
@@ -22,6 +22,9 @@ async function readEnvFlags(): Promise<string[]> {
   try {
     const res = await fetch('/api/env-check', { cache: 'no-store' });
     const json = await res.json();
+    if (Array.isArray(json?.missing)) {
+      return json.missing as string[];
+    }
     const missing: string[] = [];
     if (!json?.flags?.API_KEY) missing.push('NEXT_PUBLIC_FIREBASE_API_KEY');
     if (!json?.flags?.AUTH_DOMAIN) missing.push('NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN');

--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -22,6 +22,9 @@ async function readEnvFlags(): Promise<string[]> {
   try {
     const res = await fetch('/api/env-check', { cache: 'no-store' });
     const json = await res.json();
+    if (Array.isArray(json?.missing)) {
+      return json.missing as string[];
+    }
     const missing: string[] = [];
     if (!json?.flags?.API_KEY) missing.push('NEXT_PUBLIC_FIREBASE_API_KEY');
     if (!json?.flags?.AUTH_DOMAIN) missing.push('NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN');

--- a/apps/web/app/api/env-check/route.ts
+++ b/apps/web/app/api/env-check/route.ts
@@ -1,15 +1,29 @@
 import { NextResponse } from 'next/server';
 
+const REQUIRED_ENV = {
+  API_KEY: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+  AUTH_DOMAIN: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+  PROJECT_ID: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+  STORAGE_BUCKET: process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
+  APP_ID: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+} as const;
+
 export function GET() {
+  const flags = {
+    API_KEY: Boolean(REQUIRED_ENV.API_KEY),
+    AUTH_DOMAIN: Boolean(REQUIRED_ENV.AUTH_DOMAIN),
+    PROJECT_ID: Boolean(REQUIRED_ENV.PROJECT_ID),
+    STORAGE_BUCKET: Boolean(REQUIRED_ENV.STORAGE_BUCKET),
+    APP_ID: Boolean(REQUIRED_ENV.APP_ID),
+  } as const;
+
+  const missing = Object.entries(flags)
+    .filter(([, isPresent]) => !isPresent)
+    .map(([key]) => `NEXT_PUBLIC_FIREBASE_${key}`);
+
   return NextResponse.json({
-    ok: true,
-    flags: {
-      API_KEY: !!process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
-      AUTH_DOMAIN: !!process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
-      PROJECT_ID: !!process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
-      STORAGE_BUCKET: !!process.env.NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET,
-      APP_ID: !!process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
-      MEASUREMENT_ID: !!process.env.NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID,
-    },
+    ok: missing.length === 0,
+    flags,
+    missing,
   });
 }


### PR DESCRIPTION
## Summary
- ensure the env-check API reads Firebase keys statically and reports missing required values
- surface the server-reported missing keys on the sign-in and sign-up screens when auth is unavailable

## Testing
- pnpm web:build
- pnpm web:start
- pnpm web:snap

------
https://chatgpt.com/codex/tasks/task_e_68d92ac3c8f08327bbc1de7690c165fb