### PR TITLE
feat: protect dashboard with auth gate

### DIFF
--- a/apps/web/src/components/auth/AuthNav.tsx
+++ b/apps/web/src/components/auth/AuthNav.tsx
@@ -24,6 +24,8 @@ const SIGN_UP_ROUTES = {
   en: "/en/sign-up",
 } satisfies Record<Locale, `/${Locale}/sign-up`>;
 
+type AuthState = "guest" | "authenticated";
+
 type AuthNavProps = {
   layout?: "row" | "column";
   className?: string;
@@ -37,7 +39,7 @@ export default function AuthNav({
   onNavigate,
   fallbackLocale
 }: AuthNavProps) {
-  const [authed, setAuthed] = useState<boolean | null>(null);
+  const [authState, setAuthState] = useState<AuthState>("guest");
   const app = getClientApp();
   const { locale } = (useParams<{ locale?: string }>() ?? {}) as { locale?: string };
   const pathname = usePathname();
@@ -48,13 +50,17 @@ export default function AuthNav({
 
   useEffect(() => {
     if (!app) {
-      setAuthed(false);
+      setAuthState("guest");
       return;
     }
-    return onAuthStateChanged(getAuth(app), (u) => setAuthed(!!u));
+
+    const auth = getAuth(app);
+    return onAuthStateChanged(auth, (user) => {
+      setAuthState(user ? "authenticated" : "guest");
+    });
   }, [app]);
 
-  const isLoggedIn = !!authed;
+  const isLoggedIn = authState === "authenticated";
   const containerClasses =
     layout === "column"
       ? "flex flex-col gap-3 w-full"


### PR DESCRIPTION
## Summary
- update the session-aware AuthNav to show guest or authenticated CTA labels
- redirect unauthenticated visitors to the locale-specific sign-in page through AuthGate
- guard the localized dashboard by wrapping the page in the client-side AuthGate

## Testing
- pnpm web:build
- pnpm web:start
- pnpm web:snap *(fails: playwright binary missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d930ecdabc8327895d67db2589963b