### PR TITLE
feat: enhance auth flows and dark theme accessibility

### DIFF
--- a/apps/web/app/[locale]/sign-in/page.tsx
+++ b/apps/web/app/[locale]/sign-in/page.tsx
@@ -10,6 +10,7 @@ import { AuthProviderButtons } from "@/components/auth/AuthProviderButtons";
 import { EmailField, PasswordField } from "@/components/auth/AuthFormParts";
 import { Button } from "@/components/ui/button";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { clientEnvFlags } from "@/lib/env-flags-client";
 import { getFirebaseAuth } from "@/lib/firebase-client";
 import { ensureUserDoc } from "@/lib/user-profile";
@@ -46,7 +47,7 @@ export default function SignInPage() {
     () => ({
       "auth/user-not-found": "Email belum terdaftar.",
       "auth/wrong-password": "Password salah.",
-      "auth/too-many-requests": "Terlalu banyak percobaan. Coba beberapa saat lagi.",
+      "auth/too-many-requests": "Terlalu banyak percobaan. Coba lagi nanti.",
       "auth/invalid-credential": "Kredensial tidak valid.",
     }),
     []
@@ -139,8 +140,7 @@ export default function SignInPage() {
         <AuthProviderButtons
           onSuccess={handleEnsureUser}
           onError={(err) => {
-            const firebaseError = err as { code?: string };
-            setError(mapError(firebaseError.code));
+            setError(err.message || mapError((err as { code?: string }).code));
           }}
         />
         <div className="relative flex items-center gap-3 text-xs text-muted-foreground">
@@ -172,10 +172,13 @@ export default function SignInPage() {
             </Link>
           </div>
           {error ? (
-            <div className="flex items-start gap-2 rounded-xl border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-              <AlertCircle className="mt-0.5 h-4 w-4" aria-hidden="true" />
-              <span>{error}</span>
-            </div>
+            <Alert variant="destructive" className="w-full">
+              <AlertCircle className="h-4 w-4" aria-hidden="true" />
+              <div>
+                <AlertTitle>Gagal masuk</AlertTitle>
+                <AlertDescription>{error}</AlertDescription>
+              </div>
+            </Alert>
           ) : null}
           <Button type="submit" className="w-full" disabled={loading}>
             {loading ? (

--- a/apps/web/app/api/auth/request-password-reset/route.ts
+++ b/apps/web/app/api/auth/request-password-reset/route.ts
@@ -1,0 +1,124 @@
+import crypto from "node:crypto";
+
+import { NextResponse } from "next/server";
+import { Timestamp } from "firebase-admin/firestore";
+
+import { getFirebaseAdminFirestore } from "@/lib/firebase-admin";
+import { isValidEmailFormat, normalizeEmail } from "@/lib/email";
+
+const RATE_LIMIT_WINDOW_MS = 1000 * 60 * 60 * 3; // 3 hours
+
+function getRetryAfterMinutes(lastSentMs: number, nowMs: number) {
+  const diff = RATE_LIMIT_WINDOW_MS - (nowMs - lastSentMs);
+  return Math.max(1, Math.ceil(diff / (1000 * 60)));
+}
+
+export async function POST(request: Request) {
+  const defaultMessage = "Jika email terdaftar, kami kirim tautan reset.";
+
+  let emailInput = "";
+  try {
+    const body = await request.json().catch(() => null);
+    emailInput = typeof body?.email === "string" ? body.email : "";
+  } catch (error) {
+    console.error("[password-reset] Failed to parse body", error);
+    return NextResponse.json({ message: defaultMessage });
+  }
+
+  const normalizedEmail = normalizeEmail(emailInput);
+  if (!isValidEmailFormat(normalizedEmail)) {
+    return NextResponse.json({ message: defaultMessage });
+  }
+
+  const firestore = getFirebaseAdminFirestore();
+  const apiKey = process.env.NEXT_PUBLIC_FIREBASE_API_KEY;
+  const baseUrl =
+    process.env.APP_URL ?? process.env.NEXT_PUBLIC_APP_URL ?? process.env.NEXTAUTH_URL;
+
+  if (!firestore || !apiKey) {
+    console.error("[password-reset] Missing Firebase configuration");
+    return NextResponse.json(
+      { message: "Layanan sedang tidak tersedia. Coba lagi nanti." },
+      { status: 500 }
+    );
+  }
+
+  const emailHash = crypto.createHash("sha256").update(normalizedEmail).digest("hex");
+  const docRef = firestore.collection("password_resets").doc(emailHash);
+  const now = Date.now();
+  const nowTimestamp = Timestamp.fromMillis(now);
+
+  try {
+    const snapshot = await docRef.get();
+    const data = snapshot.exists ? snapshot.data() : null;
+    const lastSentValue = data?.lastSent;
+    const lastSentMs =
+      typeof lastSentValue === "number"
+        ? lastSentValue
+        : lastSentValue instanceof Timestamp
+          ? lastSentValue.toMillis()
+          : null;
+
+    if (lastSentMs && now - lastSentMs < RATE_LIMIT_WINDOW_MS) {
+      const retryAfterMinutes = getRetryAfterMinutes(lastSentMs, now);
+      return NextResponse.json(
+        { retryAfterMinutes },
+        {
+          status: 429,
+          headers: { "Retry-After": String(retryAfterMinutes * 60) },
+        }
+      );
+    }
+
+    const actionUrl = baseUrl ? `${baseUrl.replace(/\/$/, "")}/auth/action` : undefined;
+    const response = await fetch(
+      `https://identitytoolkit.googleapis.com/v1/accounts:sendOobCode?key=${apiKey}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          requestType: "PASSWORD_RESET",
+          email: normalizedEmail,
+          continueUrl: actionUrl,
+          canHandleCodeInApp: false,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const errorPayload = (await response.json().catch(() => null)) as
+        | { error?: { message?: string } }
+        | null;
+      const message = errorPayload?.error?.message;
+
+      if (message === "EMAIL_NOT_FOUND" || message === "USER_DISABLED") {
+        // We intentionally respond with success to avoid leaking account existence.
+      } else {
+        console.error("[password-reset] sendOobCode failed", message ?? response.statusText);
+        return NextResponse.json(
+          { message: "Gagal memproses permintaan. Coba lagi nanti." },
+          { status: 500 }
+        );
+      }
+    }
+
+    const createdAtValue =
+      data?.createdAt instanceof Timestamp ? data.createdAt : Timestamp.fromMillis(now);
+    await docRef.set(
+      {
+        createdAt: createdAtValue,
+        lastSent: nowTimestamp,
+        updatedAt: nowTimestamp,
+      },
+      { merge: true }
+    );
+
+    return NextResponse.json({ message: defaultMessage });
+  } catch (error) {
+    console.error("[password-reset] Unexpected error", error);
+    return NextResponse.json(
+      { message: "Gagal memproses permintaan. Coba lagi nanti." },
+      { status: 500 }
+    );
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
     "firebase": "^11.0.1",
+    "firebase-admin": "^12.7.0",
     "framer-motion": "^11.11.17",
     "html-to-image": "^1.11.11",
     "lucide-react": "^0.451.0",

--- a/apps/web/src/components/auth/AuthNav.tsx
+++ b/apps/web/src/components/auth/AuthNav.tsx
@@ -81,7 +81,7 @@ export default function AuthNav({
     AUTH_ROUTE_SEGMENTS.some((segment) => pathname.includes(segment));
 
   if (shouldHideActions) {
-    return <div className={cn(containerClasses, className)} />;
+    return null;
   }
 
   const handleNavigate = () => {

--- a/apps/web/src/components/ui/alert.tsx
+++ b/apps/web/src/components/ui/alert.tsx
@@ -1,0 +1,62 @@
+import * as React from "react";
+import { cva, type VariantProps } from "class-variance-authority";
+
+import { cn } from "@/lib/utils";
+
+const alertVariants = cva(
+  "relative w-full rounded-xl border px-4 py-3 text-sm [&>svg+div]:translate-y-[-1px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-3 [&>svg]:text-current [&>svg~*]:pl-9",
+  {
+    variants: {
+      variant: {
+        default: "border-muted bg-muted/20 text-foreground",
+        destructive: "border-destructive/50 bg-destructive/10 text-destructive",
+        success: "border-success/40 bg-success/10 text-success",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+);
+
+export interface AlertProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof alertVariants> {}
+
+const Alert = React.forwardRef<HTMLDivElement, AlertProps>(
+  ({ className, variant, ...props }, ref) => (
+    <div
+      ref={ref}
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+);
+Alert.displayName = "Alert";
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-semibold leading-none tracking-tight", className)}
+    {...props}
+  />
+));
+AlertTitle.displayName = "AlertTitle";
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm leading-relaxed", className)}
+    {...props}
+  />
+));
+AlertDescription.displayName = "AlertDescription";
+
+export { Alert, AlertDescription, AlertTitle };

--- a/apps/web/src/components/ui/dialog.tsx
+++ b/apps/web/src/components/ui/dialog.tsx
@@ -19,10 +19,15 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+interface DialogContentProps
+  extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
+  hideClose?: boolean;
+}
+
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
+  DialogContentProps
+>(({ className, children, hideClose = false, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
     <DialogPrimitive.Content
@@ -34,10 +39,12 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full bg-white/5 p-1 text-[var(--text-muted)] transition hover:bg-white/10">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
+      {hideClose ? null : (
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full bg-white/5 p-1 text-[var(--text-muted)] transition hover:bg-white/10">
+          <X className="h-4 w-4" />
+          <span className="sr-only">Close</span>
+        </DialogPrimitive.Close>
+      )}
     </DialogPrimitive.Content>
   </DialogPortal>
 ));

--- a/apps/web/src/components/ui/select.tsx
+++ b/apps/web/src/components/ui/select.tsx
@@ -14,14 +14,14 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-11 w-full items-center justify-between rounded-xl border border-white/10 bg-white/5 px-4 text-sm text-[var(--text-primary)] shadow-inner shadow-black/20 transition-colors data-[placeholder]:text-[var(--text-muted)] hover:border-white/20 focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/40',
+      'flex h-11 w-full items-center justify-between rounded-xl border border-border bg-background/60 px-4 text-sm text-foreground transition-colors data-[placeholder]:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-0 data-[state=open]:ring-2 data-[state=open]:ring-primary',
       className
     )}
     {...props}
   >
     {children}
     <SelectPrimitive.Icon asChild>
-      <ChevronDown className="h-4 w-4 text-[var(--text-muted)]" />
+      <ChevronDown className="h-4 w-4 text-muted-foreground" />
     </SelectPrimitive.Icon>
   </SelectPrimitive.Trigger>
 ));
@@ -35,7 +35,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'z-50 min-w-[10rem] overflow-hidden rounded-xl border border-white/10 bg-surface/90 backdrop-blur-xl text-[var(--text-primary)] shadow-glow',
+        'z-50 min-w-[10rem] overflow-hidden rounded-xl border border-border bg-surface/95 text-foreground shadow-glow backdrop-blur-xl data-[state=open]:ring-2 data-[state=open]:ring-primary/40',
         className
       )}
       position={position}
@@ -51,7 +51,7 @@ const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Label ref={ref} className={cn('px-3 py-2 text-xs font-semibold uppercase text-[var(--text-muted)]', className)} {...props} />
+  <SelectPrimitive.Label ref={ref} className={cn('px-3 py-2 text-xs font-semibold uppercase text-muted-foreground', className)} {...props} />
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
@@ -62,7 +62,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full select-none items-center rounded-lg px-3 py-2 text-sm text-[var(--text-primary)] outline-none transition-colors focus:bg-white/10 focus:text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full select-none items-center rounded-lg px-3 py-2 text-sm text-foreground outline-none transition-colors focus:bg-primary/10 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}
@@ -79,7 +79,7 @@ const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
 >(({ className, ...props }, ref) => (
-  <SelectPrimitive.Separator ref={ref} className={cn('my-2 h-px bg-white/10', className)} {...props} />
+  <SelectPrimitive.Separator ref={ref} className={cn('my-2 h-px bg-border', className)} {...props} />
 ));
 SelectSeparator.displayName = SelectPrimitive.Separator.displayName;
 

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -1,0 +1,24 @@
+export function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export function getEmailDomain(email: string): string | null {
+  const normalized = normalizeEmail(email);
+  const atIndex = normalized.lastIndexOf("@");
+  if (atIndex <= 0 || atIndex === normalized.length - 1) {
+    return null;
+  }
+  return normalized.slice(atIndex + 1);
+}
+
+export function isAllowedDomain(email: string, allowedDomains: string[]): boolean {
+  const domain = getEmailDomain(email);
+  if (!domain) return false;
+  const normalizedDomain = domain.toLowerCase();
+  return allowedDomains.some((allowed) => normalizedDomain === allowed.toLowerCase());
+}
+
+export function isValidEmailFormat(email: string): boolean {
+  const normalized = normalizeEmail(email);
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(normalized);
+}

--- a/apps/web/src/lib/firebase-admin.ts
+++ b/apps/web/src/lib/firebase-admin.ts
@@ -1,0 +1,49 @@
+import { cert, getApps, initializeApp, type App } from "firebase-admin/app";
+import { getAuth, type Auth } from "firebase-admin/auth";
+import { getFirestore, type Firestore } from "firebase-admin/firestore";
+
+let adminApp: App | null = null;
+
+function initAdminApp(): App | null {
+  if (adminApp) {
+    return adminApp;
+  }
+
+  const projectId =
+    process.env.FIREBASE_PROJECT_ID ?? process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID;
+  const clientEmail = process.env.FIREBASE_CLIENT_EMAIL;
+  const privateKey = process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, "\n");
+
+  if (!projectId || !clientEmail || !privateKey) {
+    console.error("[firebase-admin] Missing service account credentials");
+    return null;
+  }
+
+  try {
+    adminApp =
+      getApps()[0] ??
+      initializeApp({
+        credential: cert({ projectId, clientEmail, privateKey }),
+      });
+    return adminApp;
+  } catch (error) {
+    console.error("[firebase-admin] Failed to initialize", error);
+    return null;
+  }
+}
+
+export function getFirebaseAdminApp(): App | null {
+  return initAdminApp();
+}
+
+export function getFirebaseAdminAuth(): Auth | null {
+  const app = initAdminApp();
+  if (!app) return null;
+  return getAuth(app);
+}
+
+export function getFirebaseAdminFirestore(): Firestore | null {
+  const app = initAdminApp();
+  if (!app) return null;
+  return getFirestore(app);
+}

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -5,17 +5,34 @@
 :root {
   color-scheme: dark;
   --nav-h: 64px;
-  --background: #0b0f1a;
-  --surface: #0f172a;
-  --text-primary: #e2e8f0;
-  --text-muted: rgba(226, 232, 240, 0.64);
-  --primary: #3b82f6;
-  --primary-foreground: #0b1220;
+  --background: 224 41% 7%;
+  --foreground: 214 32% 91%;
+  --card: 222 47% 11%;
+  --card-foreground: 214 32% 91%;
+  --popover: 222 47% 11%;
+  --popover-foreground: 214 32% 91%;
+  --surface: 222 47% 11%;
+  --surface-foreground: 214 32% 91%;
+  --muted: 217 33% 17%;
+  --muted-foreground: 215 20% 65%;
+  --accent: 224 41% 16%;
+  --accent-foreground: 214 32% 91%;
+  --border: 217 33% 24%;
+  --input: 217 33% 24%;
+  --ring: 221 83% 53%;
+  --primary: 221 83% 53%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 222 47% 17%;
+  --secondary-foreground: 214 32% 91%;
+  --destructive: 0 84% 60%;
+  --destructive-foreground: 0 0% 100%;
+  --success: 142 71% 45%;
+  --success-foreground: 0 0% 100%;
+  --text-primary: hsl(var(--foreground));
+  --text-muted: hsl(var(--muted-foreground));
   --radius-xl: 1rem;
   --radius-2xl: 1.5rem;
   --shadow-soft: 0 30px 80px -40px rgba(59, 130, 246, 0.45);
-
-
 }
 
 @media (min-width: 1024px) {
@@ -30,12 +47,31 @@ html {
 
 [data-theme='light'] {
   color-scheme: light;
-  --background: #ffffff;
-  --surface: #f8fafc;
-  --text-primary: #0f172a;
-  --text-muted: rgba(15, 23, 42, 0.68);
-  --primary: #3b82f6;
-  --primary-foreground: #f8fafc;
+  --background: 0 0% 100%;
+  --foreground: 222 47% 11%;
+  --card: 210 40% 98%;
+  --card-foreground: 222 47% 11%;
+  --popover: 0 0% 100%;
+  --popover-foreground: 222 47% 11%;
+  --surface: 210 40% 98%;
+  --surface-foreground: 222 47% 11%;
+  --muted: 210 40% 96%;
+  --muted-foreground: 215 20% 45%;
+  --accent: 210 40% 96%;
+  --accent-foreground: 222 47% 11%;
+  --border: 215 16% 87%;
+  --input: 215 16% 87%;
+  --ring: 221 83% 53%;
+  --primary: 221 83% 53%;
+  --primary-foreground: 0 0% 100%;
+  --secondary: 210 40% 96%;
+  --secondary-foreground: 222 47% 11%;
+  --destructive: 0 72% 51%;
+  --destructive-foreground: 0 0% 100%;
+  --success: 142 71% 45%;
+  --success-foreground: 0 0% 100%;
+  --text-primary: hsl(var(--foreground));
+  --text-muted: hsl(var(--muted-foreground));
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -49,7 +85,7 @@ html {
 }
 
 body {
-  @apply bg-[var(--background)] text-[var(--text-primary)] antialiased;
+  @apply bg-background text-foreground antialiased;
 }
 
 a {
@@ -64,6 +100,21 @@ a {
 :focus-visible {
   outline: 2px solid rgba(99, 102, 241, 0.85);
   outline-offset: 3px;
+}
+
+::placeholder {
+  color: hsl(var(--muted-foreground));
+  opacity: 0.9;
+}
+
+select,
+input,
+textarea {
+  color: hsl(var(--foreground));
+}
+
+.btn-primary {
+  @apply bg-primary text-white hover:bg-primary/90 disabled:opacity-60;
 }
 
 @layer utilities {

--- a/apps/web/tailwind.config.ts
+++ b/apps/web/tailwind.config.ts
@@ -1,6 +1,9 @@
 import type { Config } from 'tailwindcss';
 import defaultTheme from 'tailwindcss/defaultTheme';
 
+const withOpacityValue = (variable: `--${string}`) =>
+  `hsl(var(${variable}) / <alpha-value>)`;
+
 const config: Config = {
   content: [
     './app/**/*.{ts,tsx}',
@@ -26,32 +29,46 @@ const config: Config = {
     },
     extend: {
       colors: {
-        background: {
-          DEFAULT: '#0B0F1A',
-          light: '#FFFFFF'
+        border: withOpacityValue('--border'),
+        input: withOpacityValue('--input'),
+        ring: withOpacityValue('--ring'),
+        background: withOpacityValue('--background'),
+        foreground: withOpacityValue('--foreground'),
+        card: {
+          DEFAULT: withOpacityValue('--card'),
+          foreground: withOpacityValue('--card-foreground')
         },
-        surface: {
-          DEFAULT: '#0F172A',
-          light: '#F8FAFC'
-        },
-        secondary: '#1E293B',
-        text: {
-          DEFAULT: '#E2E8F0',
-          dark: '#0F172A'
+        popover: {
+          DEFAULT: withOpacityValue('--popover'),
+          foreground: withOpacityValue('--popover-foreground')
         },
         primary: {
-          DEFAULT: '#3B82F6',
-          foreground: '#0B1220'
+          DEFAULT: withOpacityValue('--primary'),
+          foreground: withOpacityValue('--primary-foreground')
+        },
+        secondary: {
+          DEFAULT: withOpacityValue('--secondary'),
+          foreground: withOpacityValue('--secondary-foreground')
+        },
+        muted: {
+          DEFAULT: withOpacityValue('--muted'),
+          foreground: withOpacityValue('--muted-foreground')
         },
         accent: {
-          blue: '#3B82F6',
-          indigo: '#6366F1',
-          purple: '#8B5CF6'
+          DEFAULT: withOpacityValue('--accent'),
+          foreground: withOpacityValue('--accent-foreground')
         },
-        border: '#1E293B',
-        muted: {
-          DEFAULT: 'rgba(148, 163, 184, 0.35)',
-          foreground: 'rgba(226, 232, 240, 0.72)'
+        surface: {
+          DEFAULT: withOpacityValue('--surface'),
+          foreground: withOpacityValue('--surface-foreground')
+        },
+        destructive: {
+          DEFAULT: withOpacityValue('--destructive'),
+          foreground: withOpacityValue('--destructive-foreground')
+        },
+        success: {
+          DEFAULT: withOpacityValue('--success'),
+          foreground: withOpacityValue('--success-foreground')
         }
       },
       fontFamily: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       firebase:
         specifier: ^11.0.1
         version: 11.10.0
+      firebase-admin:
+        specifier: ^12.7.0
+        version: 12.7.0
       framer-motion:
         specifier: ^11.11.17
         version: 11.18.2(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
@@ -7996,7 +7999,7 @@ snapshots:
       '@typescript-eslint/parser': 8.44.1(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -8020,7 +8023,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -8035,14 +8038,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.44.1(eslint@8.57.1)(typescript@5.6.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -8057,7 +8060,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -8086,7 +8089,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary
- adjust Tailwind theme tokens and form components for consistent dark-theme contrast
- refine auth flows with detailed errors, Gmail-only sign-up validation, onboarding persistence, and password reset rate limiting
- add Firebase Admin utilities, alert UI component, and Google popup sign-in handling

## Testing
- `CI=1 pnpm -C apps/web build`
- `pnpm web:snap` *(fails: Next.js image optimizer cannot fetch external assets in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d956cd82bc8327ae85f4e907fcb681