### PR TITLE
feat: add supabase admin client factory

### DIFF
--- a/apps/web/lib/supabase-server.ts
+++ b/apps/web/lib/supabase-server.ts
@@ -1,0 +1,21 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+
+export function supaAdmin(): SupabaseClient {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url) {
+    throw new Error('Missing NEXT_PUBLIC_SUPABASE_URL environment variable.');
+  }
+
+  if (!serviceRoleKey) {
+    throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable.');
+  }
+
+  return createClient(url, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- add a server-side helper to create a Supabase admin client using environment variables
- validate the presence of required Supabase environment variables
- disable auth session persistence for server-side usage

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da51e5a6448327b29179793bd2aeec