### PR TITLE
Add disposable domains list and MX lookup utility

### DIFF
--- a/apps/web/lib/disposable.ts
+++ b/apps/web/lib/disposable.ts
@@ -1,0 +1,7 @@
+export const DISPOSABLE = new Set<string>([
+  "mailinator.com",
+  "yopmail.com",
+  "guerrillamail.com",
+  "10minutemail.com",
+  "tempmail.com",
+]);

--- a/apps/web/lib/mx.ts
+++ b/apps/web/lib/mx.ts
@@ -1,0 +1,10 @@
+import dns from "node:dns/promises";
+
+export async function hasMx(domain: string): Promise<boolean> {
+  try {
+    const records = await dns.resolveMx(domain);
+    return records.length > 0;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- add a reusable set of common disposable email domains
- provide an MX lookup helper using the Node.js DNS promises API

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da531cab8c83279e4f67c9c0654300