### PR TITLE
Add helper to check recent OTP verification

### DIFF
--- a/apps/web/lib/otp-verified-recent.ts
+++ b/apps/web/lib/otp-verified-recent.ts
@@ -1,0 +1,34 @@
+import { supaAdmin } from "./supabase-server";
+
+/**
+ * Returns whether the provided email has a consumed OTP created within the specified time window.
+ * @param email Email address to check.
+ * @param withinMs Time window in milliseconds. Defaults to 15 minutes.
+ */
+export async function otpVerifiedRecently(
+  email: string,
+  withinMs = 15 * 60_000,
+): Promise<boolean> {
+  const normalizedEmail = email.trim().toLowerCase();
+  if (!normalizedEmail) {
+    return false;
+  }
+
+  const supabase = supaAdmin();
+  const sinceIso = new Date(Date.now() - withinMs).toISOString();
+
+  const { data, error } = await supabase
+    .from("email_otps")
+    .select("id")
+    .eq("email", normalizedEmail)
+    .eq("consumed", true)
+    .gte("created_at", sinceIso)
+    .limit(1);
+
+  if (error) {
+    console.error("[otp-verified-recent] Failed to check OTP history", error);
+    return false;
+  }
+
+  return (data?.length ?? 0) > 0;
+}


### PR DESCRIPTION
## Summary
- add a library helper to determine if an email verified an OTP within a recent timeframe using Supabase

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da580a66b883279b0824cd80befd40