### PR TITLE
Connect auth pages to Supabase authentication

### DIFF
--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -5,8 +5,8 @@ import { useParams, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AlertCircle, Loader2 } from "lucide-react";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-import { AuthProviderButtons } from "@/components/auth/AuthProviderButtons";
 import {
   EmailField,
   PasswordField,
@@ -16,68 +16,77 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import { getFirebaseAuth } from "@/lib/firebase-client";
-import { ensureUserDoc } from "@/lib/user-profile";
-import {
-  collectMissingFirebaseEnvKeys,
-  fetchMissingFirebaseEnvKeys,
-  type FirebaseEnvKey,
-} from "@/lib/firebase-env-check";
 import { isAllowedGmail, isValidEmailFormat, normalizeEmail } from "@/lib/email";
+
+function createBrowserSupabase(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    return null;
+  }
+
+  return createClient(url, anonKey);
+}
+
+const GoogleIcon = () => (
+  <svg
+    aria-hidden="true"
+    focusable="false"
+    className="h-5 w-5"
+    viewBox="0 0 24 24"
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <path
+      fill="#4285F4"
+      d="M23.49 12.27c0-.82-.07-1.64-.23-2.43H12v4.6h6.46a5.5 5.5 0 0 1-2.38 3.62v3h3.84c2.24-2.07 3.54-5.12 3.54-8.79z"
+    />
+    <path
+      fill="#34A853"
+      d="M12 24c3.2 0 5.88-1.06 7.84-2.89l-3.84-3c-1.07.74-2.45 1.18-4 1.18-3.08 0-5.69-2.08-6.62-4.88H1.4v3.08A12 12 0 0 0 12 24z"
+    />
+    <path
+      fill="#FBBC05"
+      d="M5.38 14.41a7.18 7.18 0 0 1 0-4.82V6.51H1.4a12 12 0 0 0 0 10.98l3.98-3.08z"
+    />
+    <path
+      fill="#EA4335"
+      d="M12 4.73c1.74 0 3.3.6 4.54 1.78l3.4-3.4C17.88 1.09 15.2 0 12 0 7.32 0 2.98 2.7 1.4 6.51l3.98 3.08C6.31 6.81 8.92 4.73 12 4.73z"
+    />
+  </svg>
+);
 
 export default function SignUpPage() {
   const { locale } = useParams<{ locale: string }>();
   const router = useRouter();
   const t = useTranslations("auth");
-  const auth = getFirebaseAuth();
+  const supabase = useMemo(() => createBrowserSupabase(), []);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
+  const [otpCode, setOtpCode] = useState("");
+  const [otpSent, setOtpSent] = useState(false);
+  const [countdown, setCountdown] = useState(0);
+  const [sendingCode, setSendingCode] = useState(false);
   const [loading, setLoading] = useState(false);
+  const [googleLoading, setGoogleLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [missing, setMissing] = useState<FirebaseEnvKey[]>(collectMissingFirebaseEnvKeys());
 
   useEffect(() => {
-    if (!auth) {
-      fetchMissingFirebaseEnvKeys().then((serverMissing) => {
-        if (!serverMissing.length) return;
-        setMissing((prev) => Array.from(new Set([...prev, ...serverMissing])));
-      });
-    }
-  }, [auth]);
+    if (countdown <= 0) return;
+    const timer = setInterval(() => {
+      setCountdown((value) => (value <= 1 ? 0 : value - 1));
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [countdown]);
 
   const passwordValid = useMemo(() => isPasswordValid(password), [password]);
+  const dashboardPath = useMemo(() => (locale ? `/${locale}/dashboard` : "/dashboard"), [locale]);
 
-  const mapError = useCallback((code?: string) => {
-    switch (code) {
-      case "auth/email-already-in-use":
-        return "Email sudah terdaftar.";
-      case "auth/invalid-email":
-        return "Format email tidak valid.";
-      case "auth/weak-password":
-        return "Password terlalu lemah.";
-      default:
-        return "Gagal mendaftar. Silakan coba lagi.";
-    }
-  }, []);
-
-  const handleProviderSuccess = useCallback(async () => {
-    const currentUser = getFirebaseAuth()?.currentUser;
-    if (currentUser) {
-      await ensureUserDoc(currentUser, {
-        name: currentUser.displayName ?? null,
-        credits: 50,
-        verificationPending: false,
-      });
-      if (locale) {
-        router.replace(`/${locale}/dashboard`);
-      }
-    }
-  }, [locale, router]);
-
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
+  const handleSendCode = useCallback(async () => {
+    if (sendingCode || countdown > 0) return;
     setError(null);
+
     const trimmedName = name.trim();
     const normalizedEmail = normalizeEmail(email);
 
@@ -97,81 +106,196 @@ export default function SignUpPage() {
       setError("Password belum memenuhi semua syarat.");
       return;
     }
-    if (email !== normalizedEmail) {
-      setEmail(normalizedEmail);
-    }
 
-    const currentAuth = getFirebaseAuth();
-    if (!currentAuth) {
-      const missingKeys = collectMissingFirebaseEnvKeys();
-      setMissing((prev) => Array.from(new Set([...prev, ...missingKeys])));
-      setError(
-        missingKeys.length
-          ? `Konfigurasi Firebase belum lengkap di client: ${missingKeys.join(", ")}`
-          : "Konfigurasi Firebase belum lengkap."
-      );
+    setSendingCode(true);
+    try {
+      const response = await fetch("/api/auth/request-otp", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ email: normalizedEmail }),
+      });
+      const result = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        const message =
+          typeof result?.error === "string"
+            ? result.error
+            : response.status === 429
+            ? "Terlalu sering. Coba lagi 1 menit."
+            : "Gagal mengirim kode.";
+        setError(message);
+        if (response.status === 429) {
+          setCountdown(60);
+        }
+        return;
+      }
+      if (email !== normalizedEmail) {
+        setEmail(normalizedEmail);
+      }
+      setOtpSent(true);
+      setOtpCode("");
+      setCountdown(60);
+      setError(null);
+    } catch (err) {
+      if (typeof window !== "undefined") {
+        console.error("[sign-up] Request OTP error", err);
+      }
+      setError("Terjadi kesalahan. Coba lagi nanti.");
+    } finally {
+      setSendingCode(false);
+    }
+  }, [countdown, email, name, passwordValid, sendingCode]);
+
+  const handleSubmit = useCallback(
+    async (event: React.FormEvent<HTMLFormElement>) => {
+      event.preventDefault();
+      setError(null);
+
+      const trimmedName = name.trim();
+      const normalizedEmail = normalizeEmail(email);
+      const sanitizedOtp = otpCode.trim();
+
+      if (!trimmedName) {
+        setError("Nama wajib diisi.");
+        return;
+      }
+      if (!isValidEmailFormat(normalizedEmail)) {
+        setError("Format email tidak valid.");
+        return;
+      }
+      if (!isAllowedGmail(normalizedEmail)) {
+        setError("Gunakan email @gmail.com.");
+        return;
+      }
+      if (!passwordValid) {
+        setError("Password belum memenuhi semua syarat.");
+        return;
+      }
+      if (!otpSent) {
+        setError("Kirim kode verifikasi terlebih dahulu.");
+        return;
+      }
+      if (sanitizedOtp.length !== 6) {
+        setError("Kode OTP harus 6 digit.");
+        return;
+      }
+      if (!supabase) {
+        setError("Konfigurasi Supabase belum lengkap.");
+        return;
+      }
+
+      setLoading(true);
+      try {
+        const verifyResponse = await fetch("/api/auth/verify-otp", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ email: normalizedEmail, code: sanitizedOtp }),
+        });
+        const verifyResult = await verifyResponse.json().catch(() => ({}));
+        if (!verifyResponse.ok) {
+          const message =
+            typeof verifyResult?.error === "string"
+              ? verifyResult.error
+              : "Kode salah / kadaluarsa.";
+          setError(message);
+          if (verifyResponse.status === 429) {
+            setCountdown(60);
+          }
+          return;
+        }
+
+        const completeResponse = await fetch("/api/auth/complete-signup", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({
+            full_name: trimmedName,
+            email: normalizedEmail,
+            password,
+          }),
+        });
+        const completeResult = await completeResponse.json().catch(() => ({}));
+        if (!completeResponse.ok || completeResult?.ok !== true) {
+          const message =
+            typeof completeResult?.error === "string"
+              ? completeResult.error
+              : "Gagal mendaftar. Silakan coba lagi.";
+          setError(message);
+          return;
+        }
+
+        const { error: signInError } = await supabase.auth.signInWithPassword({
+          email: normalizedEmail,
+          password,
+        });
+        if (signInError) {
+          setError(signInError.message || "Gagal masuk setelah pendaftaran.");
+          return;
+        }
+
+        router.replace(dashboardPath);
+      } catch (err) {
+        if (typeof window !== "undefined") {
+          console.error("[sign-up] Register error", err);
+        }
+        setError("Gagal mendaftar. Silakan coba lagi.");
+      } finally {
+        setLoading(false);
+      }
+    },
+    [dashboardPath, email, name, otpCode, otpSent, password, passwordValid, router, supabase]
+  );
+
+  const handleGoogleSignIn = useCallback(async () => {
+    setError(null);
+    if (!supabase) {
+      setError("Konfigurasi Supabase belum lengkap.");
       return;
     }
+    if (googleLoading) return;
 
-    setLoading(true);
+    setGoogleLoading(true);
     try {
-      const {
-        createUserWithEmailAndPassword,
-        sendEmailVerification,
-        updateProfile,
-        signOut,
-      } = await import("firebase/auth");
-      const credential = await createUserWithEmailAndPassword(currentAuth, normalizedEmail, password);
-      await updateProfile(credential.user, { displayName: trimmedName });
-      const baseUrl =
-        process.env.APP_URL ??
-        process.env.NEXT_PUBLIC_APP_URL ??
-        (typeof window !== "undefined" ? window.location.origin : undefined);
-      const actionUrl = baseUrl ? `${baseUrl.replace(/\/$/, "")}/auth/action` : undefined;
-      await sendEmailVerification(
-        credential.user,
-        actionUrl
-          ? {
-              url: actionUrl,
-            }
-          : undefined
-      );
-      await ensureUserDoc(credential.user, {
-        name: trimmedName,
-        email: credential.user.email ?? normalizedEmail,
-        credits: 0,
-        verificationPending: true,
-        onboardingCompleted: false,
+      const origin = typeof window !== "undefined" ? window.location.origin : undefined;
+      const { error: oauthError } = await supabase.auth.signInWithOAuth({
+        provider: "google",
+        options:
+          origin
+            ? {
+                redirectTo: `${origin}/auth/callback`,
+              }
+            : undefined,
       });
-      await signOut(currentAuth);
-      if (locale) {
-        router.replace(`/${locale}/verify-email?email=${encodeURIComponent(normalizedEmail)}`);
+      if (oauthError) {
+        setError(oauthError.message || "Gagal masuk dengan Google.");
+        setGoogleLoading(false);
       }
     } catch (err) {
       if (typeof window !== "undefined") {
-        console.error("[sign-up] Register error", err);
+        console.error("[sign-up] Google login error", err);
       }
-      const firebaseError = err as { code?: string };
-      setError(mapError(firebaseError.code));
-    } finally {
-      setLoading(false);
+      setError("Gagal masuk dengan Google. Coba lagi nanti.");
+      setGoogleLoading(false);
     }
-  };
+  }, [googleLoading, supabase]);
 
-  if (!auth) {
+  if (!supabase) {
     return (
       <div className="container mx-auto max-w-lg py-16">
         <CardX tone="surface" padding="lg">
           <CardXHeader
-            title="Konfigurasi Firebase belum lengkap"
-            subtitle="Lengkapi environment variable Firebase lalu jalankan ulang aplikasi."
+            title="Konfigurasi Supabase belum lengkap"
+            subtitle="Lengkapi environment variable Supabase lalu jalankan ulang aplikasi."
           />
           <ul className="space-y-1 text-sm">
-            {missing.map((key) => (
-              <li key={key} className="flex items-center gap-2">
-                <span className="rounded bg-muted px-2 py-0.5 font-mono text-xs">{key}</span>
-              </li>
-            ))}
+            <li className="flex items-center gap-2">
+              <span className="rounded bg-muted px-2 py-0.5 font-mono text-xs">
+                NEXT_PUBLIC_SUPABASE_URL
+              </span>
+            </li>
+            <li className="flex items-center gap-2">
+              <span className="rounded bg-muted px-2 py-0.5 font-mono text-xs">
+                NEXT_PUBLIC_SUPABASE_ANON_KEY
+              </span>
+            </li>
           </ul>
           <p className="mt-4 text-xs text-muted-foreground">
             Cek cepat: <a className="underline" href="/api/env-check" target="_blank" rel="noreferrer">/api/env-check</a>
@@ -188,13 +312,23 @@ export default function SignUpPage() {
           title={t("signUp")}
           subtitle="Dapatkan 50 kredit gratis setelah mendaftar."
         />
-        <AuthProviderButtons
-          onSuccess={handleProviderSuccess}
-          onError={(error) => {
-            setError(mapError((error as { code?: string }).code));
-          }}
-          disabled={loading}
-        />
+        <div className="grid gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            size="lg"
+            className="w-full justify-center gap-3 border border-border bg-background/60 text-foreground hover:bg-background"
+            disabled={googleLoading || loading || sendingCode}
+            onClick={() => void handleGoogleSignIn()}
+          >
+            {googleLoading ? (
+              <Loader2 className="h-5 w-5 animate-spin" aria-hidden="true" />
+            ) : (
+              <GoogleIcon />
+            )}
+            <span className="ml-2 text-sm font-semibold">Masuk dengan Google</span>
+          </Button>
+        </div>
         <div className="relative flex items-center gap-3 text-xs text-muted-foreground">
           <span className="flex-1 border-t border-border/70" />
           <span>atau daftar dengan email</span>
@@ -230,6 +364,26 @@ export default function SignUpPage() {
             showStrength
             inputClassName="text-white placeholder:text-muted-foreground"
           />
+          {otpSent ? (
+            <div className="space-y-2">
+              <label htmlFor="otp" className="text-sm font-medium text-foreground">
+                Kode verifikasi
+              </label>
+              <Input
+                id="otp"
+                value={otpCode}
+                onChange={(event) =>
+                  setOtpCode(event.target.value.replace(/\D/g, "").slice(0, 6))
+                }
+                placeholder="123456"
+                inputMode="numeric"
+                pattern="\d*"
+                maxLength={6}
+                className="text-white placeholder:text-muted-foreground"
+                required
+              />
+            </div>
+          ) : null}
           {error ? (
             <Alert variant="destructive" className="w-full">
               <AlertCircle className="h-4 w-4" aria-hidden="true" />
@@ -239,7 +393,28 @@ export default function SignUpPage() {
               </div>
             </Alert>
           ) : null}
-          <Button type="submit" className="w-full btn-primary text-white" disabled={loading}>
+          <Button
+            type="button"
+            className="w-full btn-primary text-white"
+            disabled={sendingCode || countdown > 0 || loading}
+            onClick={() => void handleSendCode()}
+          >
+            {sendingCode ? (
+              <span className="flex items-center justify-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                Mengirim kode...
+              </span>
+            ) : countdown > 0 ? (
+              `Kirim ulang (${countdown})`
+            ) : (
+              "Kirim Kode"
+            )}
+          </Button>
+          <Button
+            type="submit"
+            className="w-full btn-primary text-white"
+            disabled={loading || !otpSent || otpCode.trim().length !== 6}
+          >
             {loading ? (
               <span className="flex items-center justify-center gap-2">
                 <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-slot": "^1.1.0",
     "@radix-ui/react-tooltip": "^1.1.3",
     "@sentry/nextjs": "^8.32.0",
+    "@supabase/supabase-js": "^2.45.4",
     "@tanstack/react-query": "^5.62.8",
     "@tanstack/react-table": "^8.20.5",
     "class-variance-authority": "^0.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@sentry/nextjs':
         specifier: ^8.32.0
         version: 8.55.0(@opentelemetry/context-async-hooks@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/core@1.30.1(@opentelemetry/api@1.9.0))(@opentelemetry/instrumentation@0.57.2(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@1.30.1(@opentelemetry/api@1.9.0))(next@15.0.3(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(@playwright/test@1.55.1)(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)(webpack@5.101.3)
+      '@supabase/supabase-js':
+        specifier: ^2.45.4
+        version: 2.58.0
       '@tanstack/react-query':
         specifier: ^5.62.8
         version: 5.90.2(react@19.0.0-rc-66855b96-20241106)
@@ -1993,6 +1996,28 @@ packages:
     peerDependencies:
       webpack: '>=4.40.0'
 
+  '@supabase/auth-js@2.72.0':
+    resolution: {integrity: sha512-4+bnUrtTDK1YD0/FCx2YtMiQH5FGu9Jlf4IQi5kcqRwRwqp2ey39V61nHNdH86jm3DIzz0aZKiWfTW8qXk1swQ==}
+
+  '@supabase/functions-js@2.5.0':
+    resolution: {integrity: sha512-SXBx6Jvp+MOBekeKFu+G11YLYPeVeGQl23eYyAG9+Ro0pQ1aIP0UZNIBxHKNHqxzR0L0n6gysNr2KT3841NATw==}
+
+  '@supabase/node-fetch@2.6.15':
+    resolution: {integrity: sha512-1ibVeYUacxWYi9i0cf5efil6adJ9WRyZBLivgjs+AUpewx1F3xPi7gLgaASI2SmIQxPoCEjAsLAzKPgMJVgOUQ==}
+    engines: {node: 4.x || >=6.0.0}
+
+  '@supabase/postgrest-js@1.21.4':
+    resolution: {integrity: sha512-TxZCIjxk6/dP9abAi89VQbWWMBbybpGWyvmIzTd79OeravM13OjR/YEYeyUOPcM1C3QyvXkvPZhUfItvmhY1IQ==}
+
+  '@supabase/realtime-js@2.15.5':
+    resolution: {integrity: sha512-/Rs5Vqu9jejRD8ZeuaWXebdkH+J7V6VySbCZ/zQM93Ta5y3mAmocjioa/nzlB6qvFmyylUgKVS1KpE212t30OA==}
+
+  '@supabase/storage-js@2.12.2':
+    resolution: {integrity: sha512-SiySHxi3q7gia7NBYpsYRu8gyI0NhFwSORMxbZIxJ/zAVkN6QpwDRan158CJ+UdzD4WB/rQMAGRqIJQP+7ccAQ==}
+
+  '@supabase/supabase-js@2.58.0':
+    resolution: {integrity: sha512-Tm1RmQpoAKdQr4/8wiayGti/no+If7RtveVZjHR8zbO7hhQjmPW2Ok5ZBPf1MGkt5c+9R85AVMsTfSaqAP1sUg==}
+
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
 
@@ -2102,6 +2127,9 @@ packages:
   '@types/pg@8.6.1':
     resolution: {integrity: sha512-1Kc4oAGzAl7uqUStZCDvaLFqZrW9qWSjXOmBfdgyBP5La7Us6Mg4GBvRlSoaZMhQF/zSj1C8CtKMBkoiT8eL8w==}
 
+  '@types/phoenix@1.6.6':
+    resolution: {integrity: sha512-PIzZZlEppgrpoT2QgbnDU+MMzuR6BbCjllj0bM70lWoejMeNJAxCchxnv7J3XFkI8MpygtRpzXrIlmWUBclP5A==}
+
   '@types/qs@6.14.0':
     resolution: {integrity: sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==}
 
@@ -2137,6 +2165,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@typescript-eslint/eslint-plugin@8.44.1':
     resolution: {integrity: sha512-molgphGqOBT7t4YKCSkbasmu1tb1MgrZ2szGzHbclF7PNmOkSTQVHy+2jXOSnxvR3+Xe1yySHFZoqMpz3TfQsw==}
@@ -4988,6 +5019,18 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -6927,6 +6970,48 @@ snapshots:
       - encoding
       - supports-color
 
+  '@supabase/auth-js@2.72.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/functions-js@2.5.0':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/node-fetch@2.6.15':
+    dependencies:
+      whatwg-url: 5.0.0
+
+  '@supabase/postgrest-js@1.21.4':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/realtime-js@2.15.5':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+      '@types/phoenix': 1.6.6
+      '@types/ws': 8.18.1
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/storage-js@2.12.2':
+    dependencies:
+      '@supabase/node-fetch': 2.6.15
+
+  '@supabase/supabase-js@2.58.0':
+    dependencies:
+      '@supabase/auth-js': 2.72.0
+      '@supabase/functions-js': 2.5.0
+      '@supabase/node-fetch': 2.6.15
+      '@supabase/postgrest-js': 1.21.4
+      '@supabase/realtime-js': 2.15.5
+      '@supabase/storage-js': 2.12.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/counter@0.1.3': {}
 
   '@swc/helpers@0.5.13':
@@ -7060,6 +7145,8 @@ snapshots:
       pg-protocol: 1.10.3
       pg-types: 2.2.0
 
+  '@types/phoenix@1.6.6': {}
+
   '@types/qs@6.14.0': {}
 
   '@types/range-parser@1.2.7': {}
@@ -7105,6 +7192,10 @@ snapshots:
 
   '@types/tough-cookie@4.0.5':
     optional: true
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 20.19.17
 
   '@typescript-eslint/eslint-plugin@8.44.1(@typescript-eslint/parser@8.44.1(eslint@8.57.1)(typescript@5.6.3))(eslint@8.57.1)(typescript@5.6.3)':
     dependencies:
@@ -10533,6 +10624,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  ws@8.18.3: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## Summary
- replace the Firebase-powered sign-in handlers with Supabase email/password and Google OAuth flows that redirect to the dashboard
- rework the sign-up page to request and verify OTP codes via the new auth API, complete the signup, and sign the user in with Supabase

## Testing
- pnpm -C apps/web lint *(fails: interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68da5dd84d0483278c241cf1b4ca5d6a