### PR TITLE
Add Supabase OTP schema and env example for web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,23 +28,27 @@ Monorepo untuk platform kreatif UMKM Kits Studio. Struktur ini terdiri atas apli
    pnpm install
    ```
 
-2. **Salin berkas environment**
+2. **Salin dan isi berkas environment**
 
    ```bash
-   cp .env.example .env.local
+   cp apps/web/.env.example apps/web/.env.local
    ```
 
-   Sesuaikan nilai variabel sesuai kredensial Supabase, Midtrans, dan n8n Anda sebelum menjalankan produksi. Nilai contoh aman untuk build lokal.
+   Buka `apps/web/.env.local` kemudian isi seluruh variabel dengan kredensial Supabase, SMTP, dan URL aplikasi Anda sebelum menjalankan secara lokal maupun produksi.
 
-3. **Jalankan UI Next.js**
+3. **Buat tabel OTP di Supabase**
+
+   Jalankan isi dari `apps/web/supabase.sql` di Supabase SQL Editor agar tabel `email_otps` tersedia.
+
+4. **Jalankan UI Next.js**
 
    ```bash
-   pnpm -C apps/web dev
+   pnpm -C apps/web install && pnpm -C apps/web dev
    ```
 
    Aplikasi akan tersedia di `http://localhost:3000`. Landing page mendukung bahasa `id` (default) dan `en`.
 
-4. **Testing**
+5. **Testing**
 
    ```bash
    pnpm test

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,10 @@
-NEXT_PUBLIC_SUPABASE_URL=
-NEXT_PUBLIC_SUPABASE_ANON_KEY=
-SUPABASE_SERVICE_ROLE_KEY=
-NEXT_PUBLIC_API_BASE=http://localhost:3000/api
+NEXT_PUBLIC_SUPABASE_URL=your-supabase-url
+NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+APP_URL=http://localhost:3000
+SESSION_SECRET=replace-with-random-secret
+SMTP_HOST=smtp.example.com
+SMTP_PORT=587
+SMTP_USER=your-smtp-username
+SMTP_PASS=your-smtp-password
+EMAIL_FROM="UMKM Kits Studio <noreply@example.com>"

--- a/apps/web/supabase.sql
+++ b/apps/web/supabase.sql
@@ -1,0 +1,17 @@
+-- email OTP storage
+create extension if not exists "pgcrypto";
+
+create table if not exists public.email_otps (
+  id uuid primary key default gen_random_uuid(),
+  email text not null,
+  code_hash text not null,
+  consumed boolean not null default false,
+  attempt_count integer not null default 0,
+  expires_at timestamptz not null,
+  last_sent_at timestamptz not null,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create index if not exists email_otps_email_idx on public.email_otps (email);
+create index if not exists email_otps_consumed_idx on public.email_otps (consumed);
+create index if not exists email_otps_expires_at_idx on public.email_otps (expires_at);


### PR DESCRIPTION
## Summary
- add environment variable template for the Next.js app and document setup steps
- provide the Supabase SQL schema for the email OTP workflow and link it from the README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68da9142ccec8327bac3aa789715bf7d