### PR TITLE
feat: migrate web auth flows to Supabase

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Monorepo untuk platform kreatif UMKM Kits Studio. Struktur ini terdiri atas apli
 
 ## Deploy
 
-1. Deploy UI ke Vercel dan set `NEXT_PUBLIC_API_BASE` mengarah ke layanan backend Anda.
+1. Deploy UI ke Vercel dan set variabel Supabase (`NEXT_PUBLIC_SUPABASE_URL`, `NEXT_PUBLIC_SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY`).
 2. Kelola storage, auth, dan edge functions melalui Supabase Project yang terhubung.
 3. Pastikan domain Vercel, staging, dan produksi masuk ke variabel `CORS_ALLOWED_ORIGINS`.
 4. Verifikasi endpoint `GET /api-health` berjalan dan menampilkan status lingkungan.

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -3,13 +3,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:5001";
-
-function buildUrl(path: string) {
-  const base = API_BASE.endsWith("/") ? API_BASE.slice(0, -1) : API_BASE;
-  return `${base}${path}`;
-}
-
 type SubmitState = "idle" | "loading" | "success" | "error";
 
 export default function LoginEmailPage() {
@@ -37,11 +30,10 @@ export default function LoginEmailPage() {
       setStatus("loading");
       setMessage("Mengirim kode...");
       try {
-        const response = await fetch(buildUrl("/auth/request-otp"), {
+        const response = await fetch("/api/auth/request-otp", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ email: sanitizedEmail }),
-          credentials: "include"
         });
         const result = await response.json().catch(() => ({}));
         if (!response.ok) {

--- a/apps/web/app/(auth)/otp/page.tsx
+++ b/apps/web/app/(auth)/otp/page.tsx
@@ -3,13 +3,6 @@
 import { Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 
-const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:5001";
-
-function buildUrl(path: string) {
-  const base = API_BASE.endsWith("/") ? API_BASE.slice(0, -1) : API_BASE;
-  return `${base}${path}`;
-}
-
 type SubmitState = "idle" | "loading" | "success" | "error";
 
 function OtpContent() {
@@ -53,11 +46,10 @@ function OtpContent() {
       setStatus("loading");
       setMessage("Memverifikasi kode...");
       try {
-        const response = await fetch(buildUrl("/auth/verify-otp"), {
+        const response = await fetch("/api/auth/verify-otp", {
           method: "POST",
           headers: { "content-type": "application/json" },
           body: JSON.stringify({ email: targetEmail, code }),
-          credentials: "include"
         });
         const result = await response.json().catch(() => ({}));
         if (!response.ok) {
@@ -88,11 +80,10 @@ function OtpContent() {
     setStatus("loading");
     setMessage("Mengirim ulang kode...");
     try {
-      const response = await fetch(buildUrl("/auth/request-otp"), {
+      const response = await fetch("/api/auth/request-otp", {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ email: targetEmail }),
-        credentials: "include"
       });
       const result = await response.json().catch(() => ({}));
       if (!response.ok) {

--- a/apps/web/app/[locale]/dashboard/page.tsx
+++ b/apps/web/app/[locale]/dashboard/page.tsx
@@ -79,15 +79,8 @@ export default function DashboardPage() {
   }, [supabase, user]);
 
   useEffect(() => {
-    const base = process.env.NEXT_PUBLIC_API_BASE;
-    if (!base) {
-      setError('NEXT_PUBLIC_API_BASE belum disetel.');
-      return;
-    }
     setLoading(true);
-    fetch(`${base}/api/ai/jobs?limit=5`, {
-      credentials: 'include'
-    })
+    fetch('/api/ai/jobs?limit=5', { credentials: 'include' })
       .then(async (response) => {
         if (!response.ok) throw new Error('Gagal memuat job.');
         return response.json();

--- a/apps/web/app/[locale]/sign-in/page.tsx
+++ b/apps/web/app/[locale]/sign-in/page.tsx
@@ -6,23 +6,13 @@ import { useTranslations } from "next-intl";
 import type { Route } from "next";
 import { useCallback, useMemo, useState } from "react";
 import { AlertCircle, Loader2 } from "lucide-react";
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 import { EmailField, PasswordField } from "@/components/auth/AuthFormParts";
 import { Button } from "@/components/ui/button";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-
-function createBrowserSupabase(): SupabaseClient | null {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!url || !anonKey) {
-    return null;
-  }
-
-  return createClient(url, anonKey);
-}
+import { supaBrowser } from "@/lib/supabase-browser";
 
 const GoogleIcon = () => (
   <svg
@@ -60,7 +50,7 @@ export default function SignInPage() {
   const [loading, setLoading] = useState(false);
   const [googleLoading, setGoogleLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const supabase = useMemo<SupabaseClient | null>(() => supaBrowser(), []);
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();

--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -6,7 +6,7 @@ import { useParams, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AlertCircle, Loader2 } from "lucide-react";
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 import {
   EmailField,
@@ -17,18 +17,9 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { supaBrowser } from "@/lib/supabase-browser";
 import { isAllowedGmail, isValidEmailFormat, normalizeEmail } from "@/lib/email";
 
-function createBrowserSupabase(): SupabaseClient | null {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  if (!url || !anonKey) {
-    return null;
-  }
-
-  return createClient(url, anonKey);
-}
 
 const GoogleIcon = () => (
   <svg
@@ -61,7 +52,7 @@ export default function SignUpPage() {
   const { locale } = useParams<{ locale: string }>();
   const router = useRouter();
   const t = useTranslations("auth");
-  const supabase = useMemo(() => createBrowserSupabase(), []);
+  const supabase = useMemo<SupabaseClient | null>(() => supaBrowser(), []);
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");

--- a/apps/web/app/api-health/route.ts
+++ b/apps/web/app/api-health/route.ts
@@ -5,7 +5,8 @@ export function GET() {
     status: 'ok',
     time: new Date().toISOString(),
     env: {
-      hasApiBase: Boolean(process.env.NEXT_PUBLIC_API_BASE),
+      hasSupabaseUrl: Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL),
+      hasSupabaseAnonKey: Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
       nodeEnv: process.env.NODE_ENV
     }
   });

--- a/apps/web/app/api/auth/request-otp/route.ts
+++ b/apps/web/app/api/auth/request-otp/route.ts
@@ -81,6 +81,9 @@ export async function POST(request: Request) {
   const codeHash = await bcrypt.hash(code, 10);
   const issuedAt = new Date(now);
   const expiresAt = new Date(now + OTP_EXPIRY_MS);
+  const forwardedFor = request.headers.get("x-forwarded-for");
+  const createdIp =
+    forwardedFor?.split(",")[0]?.trim() ?? request.headers.get("x-real-ip") ?? null;
 
   const { data: insertedRows, error: insertError } = await supabase
     .from("email_otps")
@@ -92,6 +95,7 @@ export async function POST(request: Request) {
       attempt_count: 0,
       last_sent_at: issuedAt.toISOString(),
       created_at: issuedAt.toISOString(),
+      created_ip: createdIp,
     })
     .select("id");
 

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,0 +1,34 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+let browserClient: SupabaseClient | null = null;
+
+export function supaBrowser(): SupabaseClient | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  if (browserClient) {
+    return browserClient;
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!url || !anonKey) {
+    console.error("[supabase-browser] Missing Supabase env vars in browser context.");
+    return null;
+  }
+
+  browserClient = createClient(url, anonKey, {
+    auth: {
+      persistSession: true,
+      storageKey: "umkmkits.supabase.auth",
+    },
+  });
+
+  return browserClient;
+}
+
+export function resetSupaBrowserClient() {
+  browserClient = null;
+}

--- a/apps/web/src/components/auth/AuthProviderButtons.tsx
+++ b/apps/web/src/components/auth/AuthProviderButtons.tsx
@@ -78,11 +78,16 @@ export function AuthProviderButtons({
           if (!supabase) {
             throw new Error("Supabase belum terkonfigurasi");
           }
+          const origin = typeof window !== "undefined" ? window.location.origin : undefined;
           const { error } = await supabase.auth.signInWithOAuth({
             provider: "google",
-            options: {
-              queryParams: { prompt: "select_account" },
-            },
+            options:
+              origin
+                ? {
+                    redirectTo: `${origin}/auth/callback`,
+                    queryParams: { prompt: "select_account" },
+                  }
+                : { queryParams: { prompt: "select_account" } },
           });
           if (error) {
             throw error;

--- a/apps/web/src/components/editor/Toolbar.tsx
+++ b/apps/web/src/components/editor/Toolbar.tsx
@@ -109,7 +109,6 @@ export function Toolbar() {
   };
 
   const triggerAI = async (action: 'enhance' | 'img2img' | 'caption') => {
-    const baseUrl = (process.env.NEXT_PUBLIC_API_BASE ?? '').replace(/\/$/, '') || '/api';
     setRunningAction(action);
     const jobId = crypto.randomUUID();
     const imageLayer = layers.find((layer) => layer.type === 'image' && layer.visible) as typeof layers[number] | undefined;
@@ -143,7 +142,7 @@ export function Toolbar() {
       }
 
       upsertJob({ id: jobId, action, status: 'pending', message: 'Job dikirim ke AI.' });
-      const response = await fetch(`${baseUrl}/editor/${action}`, {
+      const response = await fetch(`/api/editor/${action}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body)

--- a/apps/web/src/lib/supabase-client.ts
+++ b/apps/web/src/lib/supabase-client.ts
@@ -1,41 +1,9 @@
-import { createClient, type Session, type SupabaseClient } from '@supabase/supabase-js';
+import type { Session, SupabaseClient } from '@supabase/supabase-js';
 
-let browserClient: SupabaseClient | null = null;
-
-function createBrowserClient(): SupabaseClient | null {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  if (browserClient) {
-    return browserClient;
-  }
-
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
-  const missing: string[] = [];
-  if (!url) missing.push('NEXT_PUBLIC_SUPABASE_URL');
-  if (!anonKey) missing.push('NEXT_PUBLIC_SUPABASE_ANON_KEY');
-
-  if (missing.length > 0) {
-    console.error('[supabase-client] Missing ENV (client bundle):', missing.join(', '));
-    return null;
-  }
-
-  browserClient = createClient(url!, anonKey!, {
-    auth: {
-      persistSession: true,
-      autoRefreshToken: true,
-      detectSessionInUrl: true,
-    },
-  });
-
-  return browserClient;
-}
+import { resetSupaBrowserClient, supaBrowser } from '@/lib/supabase-browser';
 
 export function getSupabaseBrowserClient(): SupabaseClient | null {
-  return createBrowserClient();
+  return supaBrowser();
 }
 
 export async function getSupabaseSession(): Promise<Session | null> {
@@ -50,5 +18,5 @@ export async function getSupabaseSession(): Promise<Session | null> {
 }
 
 export function resetSupabaseBrowserClient() {
-  browserClient = null;
+  resetSupaBrowserClient();
 }

--- a/apps/web/supabase.sql
+++ b/apps/web/supabase.sql
@@ -9,6 +9,7 @@ create table if not exists public.email_otps (
   attempt_count integer not null default 0,
   expires_at timestamptz not null,
   last_sent_at timestamptz not null,
+  created_ip text,
   created_at timestamptz not null default timezone('utc', now())
 );
 


### PR DESCRIPTION
## Summary
- add a singleton Supabase browser client and reuse it across auth utilities
- rewire sign-in/sign-up flows for Supabase password, Google OAuth, and OTP-backed signup without altering UI
- enforce same-origin API usage while strengthening OTP persistence with requester IP metadata and updated docs

## Testing
- pnpm -C apps/web lint *(fails: interactive setup prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68daaca6b99c8327a975aa5ddeb0acc3