### PR TITLE
Fix Supabase auth session flow

### DIFF
--- a/apps/web/app/[locale]/auth/action/page.tsx
+++ b/apps/web/app/[locale]/auth/action/page.tsx
@@ -12,7 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
-import type { SupabaseClient } from "@supabase/supabase-js";
+import type { SupabaseBrowserClient } from "@/lib/supabase-browser";
 import { getSupabaseBrowserClient } from "@/lib/supabase-client";
 import { cn } from "@/lib/utils";
 import {
@@ -31,7 +31,7 @@ export default function AuthActionPage() {
   const searchParams = useSearchParams();
   const { locale } = useParams<{ locale: string }>();
   const router = useRouter();
-  const supabase = useMemo<SupabaseClient | null>(() => {
+  const supabase = useMemo<SupabaseBrowserClient | null>(() => {
     try {
       return getSupabaseBrowserClient();
     } catch (error) {

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { Suspense, useEffect } from "react";
+import type { Route } from "next";
 import { useRouter, useSearchParams } from "next/navigation";
 import { supaBrowser } from "@/lib/supabase-browser";
 import type { SupabaseClient } from "@supabase/supabase-js";
@@ -31,7 +32,13 @@ function Inner() {
         headers: { Authorization: `Bearer ${session.access_token}` },
       }).catch(() => {});
 
-      router.replace(search.get("redirect") || "/dashboard");
+      const redirectParam = search.get("redirect");
+      const target =
+        redirectParam && redirectParam.startsWith("/")
+          ? (redirectParam as Route)
+          : ("/dashboard" as Route);
+
+      router.replace(target);
     })();
   }, [router, search]);
 

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -2,7 +2,6 @@
 
 import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import type { Route } from "next";
 import { supaBrowser } from "@/lib/supabase-browser";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
@@ -32,12 +31,7 @@ function Inner() {
         headers: { Authorization: `Bearer ${session.access_token}` },
       }).catch(() => {});
 
-      const redirectParam = search.get("redirect");
-      const destination =
-        redirectParam && redirectParam.startsWith("/")
-          ? (redirectParam as Route)
-          : ("/dashboard" as Route);
-      router.replace(destination);
+      router.replace(search.get("redirect") || "/dashboard");
     })();
   }, [router, search]);
 

--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -4,7 +4,6 @@ import { Suspense, useEffect } from "react";
 import type { Route } from "next";
 import { useRouter, useSearchParams } from "next/navigation";
 import { supaBrowser } from "@/lib/supabase-browser";
-import type { SupabaseClient } from "@supabase/supabase-js";
 
 export const dynamic = "force-dynamic";
 
@@ -14,7 +13,7 @@ function Inner() {
 
   useEffect(() => {
     (async () => {
-      const sb: SupabaseClient = supaBrowser();
+      const sb = supaBrowser();
 
       const code = search.get("code");
       if (code) {

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,9 +1,11 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-let _client: SupabaseClient | null = null;
+export type SupabaseBrowserClient = SupabaseClient<any, "public", "public", any, any>;
 
-export function supaBrowser(): SupabaseClient {
+let _client: SupabaseBrowserClient | null = null;
+
+export function supaBrowser(): SupabaseBrowserClient {
   if (_client) return _client;
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
@@ -29,7 +31,7 @@ export function supaBrowser(): SupabaseClient {
       },
     },
     auth: { persistSession: true, detectSessionInUrl: true, autoRefreshToken: true },
-  });
+  }) as unknown as SupabaseBrowserClient;
 
   return _client;
 }

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,4 +1,5 @@
-import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import { createBrowserClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
 let _client: SupabaseClient | null = null;
 
@@ -7,21 +8,32 @@ export function supaBrowser(): SupabaseClient {
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;
   const anon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!;
-  if (!url || !anon) {
-    throw new Error("[supabase-browser] Missing NEXT_PUBLIC_SUPABASE_URL / NEXT_PUBLIC_SUPABASE_ANON_KEY");
-  }
+  if (!url || !anon) throw new Error("[supabase-browser] Missing NEXT_PUBLIC_SUPABASE_*");
 
-  _client = createClient(url, anon, {
-    auth: {
-      persistSession: true,
-      autoRefreshToken: true,
-      detectSessionInUrl: true,
-      storageKey: "umkmkits.supabase.auth",
+  _client = createBrowserClient(url, anon, {
+    cookies: {
+      get(name) {
+        return document.cookie
+          .split("; ")
+          .find((value) => value.startsWith(`${name}=`))?.split("=")[1];
+      },
+      set(name, value, options) {
+        document.cookie = `${name}=${value}; Path=/; Max-Age=${options?.maxAge ?? 60 * 60 * 24 * 365}; SameSite=${options?.sameSite ?? "Lax"}; ${
+          location.protocol === "https:" ? "Secure" : ""
+        }`;
+      },
+      remove(name, options) {
+        document.cookie = `${name}=; Path=/; Max-Age=0; SameSite=${options?.sameSite ?? "Lax"}; ${
+          location.protocol === "https:" ? "Secure" : ""
+        }`;
+      },
     },
+    auth: { persistSession: true, detectSessionInUrl: true, autoRefreshToken: true },
   });
+
   return _client;
 }
 
-export function resetSupaBrowserClient(): void {
+export function resetSupaBrowserClient() {
   _client = null;
 }

--- a/apps/web/lib/supabase-clients.ts
+++ b/apps/web/lib/supabase-clients.ts
@@ -1,7 +1,10 @@
-import type { SupabaseClient } from "@supabase/supabase-js";
-import { resetSupaBrowserClient, supaBrowser } from "@/lib/supabase-browser";
+import {
+  type SupabaseBrowserClient,
+  resetSupaBrowserClient,
+  supaBrowser,
+} from "@/lib/supabase-browser";
 
-export function getSupabaseBrowserClient(): SupabaseClient {
+export function getSupabaseBrowserClient(): SupabaseBrowserClient {
   return supaBrowser();
 }
 

--- a/apps/web/lib/supabase-server-ssr.ts
+++ b/apps/web/lib/supabase-server-ssr.ts
@@ -1,19 +1,22 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
-import type { SupabaseClient } from "@supabase/supabase-js";
 
-export function supaServer(): SupabaseClient {
-  const c = cookies();
+export type SupabaseServerClient = ReturnType<typeof createServerClient>;
+
+export function supaServer(): SupabaseServerClient {
+  const c = cookies() as unknown as {
+    get: (name: string) => { value?: string } | undefined;
+    set: (options: { name: string; value: string } & Record<string, unknown>) => void;
+  };
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
         get: (name) => c.get(name)?.value,
-        set: (name, value, options) =>
-          c.set?.({ name, value, ...options }),
+        set: (name, value, options) => c.set({ name, value, ...options }),
         remove: (name, options) =>
-          c.set?.({ name, value: "", ...options, maxAge: 0 }),
+          c.set({ name, value: "", ...options, maxAge: 0 }),
       },
     }
   );

--- a/apps/web/lib/supabase-server-ssr.ts
+++ b/apps/web/lib/supabase-server-ssr.ts
@@ -1,34 +1,28 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
-type CookieStore = Awaited<ReturnType<typeof cookies>> & {
-  set?: (options: any) => void;
-};
-
-export function supaServer() {
-  const cookieStore = cookies() as unknown as CookieStore;
+export function supaServer(): SupabaseClient {
+  const c = cookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: any) {
-          cookieStore.set?.({ name, value, ...options });
-        },
-        remove(name: string, options: any) {
-          cookieStore.set?.({ name, value: "", ...options, maxAge: 0 });
-        },
+        get: (name) => c.get(name)?.value,
+        set: (name, value, options) =>
+          c.set?.({ name, value, ...options }),
+        remove: (name, options) =>
+          c.set?.({ name, value: "", ...options, maxAge: 0 }),
       },
     }
   );
 }
 
 export async function getServerUser() {
+  const sb = supaServer();
   const {
     data: { user },
-  } = await supaServer().auth.getUser();
+  } = await sb.auth.getUser();
   return user;
 }

--- a/apps/web/src/components/editor/Toolbar.tsx
+++ b/apps/web/src/components/editor/Toolbar.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 import { Download, FlipHorizontal2, FlipVertical2, ImageDown, Loader2, Move, RotateCw, Sparkles, Wand2 } from 'lucide-react';
 import { toBlob } from 'html-to-image';
 import { z } from 'zod';
-import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SupabaseBrowserClient } from '@/lib/supabase-browser';
 import { Button } from '@/components/ui/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Slider } from '@/components/ui/slider';
@@ -17,7 +17,7 @@ const captionSchema = z.object({ prompt: z.string().min(3) });
 const img2imgSchema = z.object({ imageUrl: z.string().url(), prompt: z.string().min(3) });
 
 async function uploadBlob(blob: Blob, format: 'png' | 'jpeg') {
-  let supabase: SupabaseClient;
+  let supabase: SupabaseBrowserClient;
   try {
     supabase = getSupabaseBrowserClient();
   } catch (error) {

--- a/apps/web/src/lib/supabase-client.ts
+++ b/apps/web/src/lib/supabase-client.ts
@@ -1,8 +1,12 @@
-import type { Session, SupabaseClient } from "@supabase/supabase-js";
+import type { Session } from "@supabase/supabase-js";
 
-import { resetSupaBrowserClient, supaBrowser } from "@/lib/supabase-browser";
+import {
+  type SupabaseBrowserClient,
+  resetSupaBrowserClient,
+  supaBrowser,
+} from "@/lib/supabase-browser";
 
-export function getSupabaseBrowserClient(): SupabaseClient {
+export function getSupabaseBrowserClient(): SupabaseBrowserClient {
   return supaBrowser();
 }
 


### PR DESCRIPTION
## Summary
- switch Supabase browser client to @supabase/ssr with cookie persistence
- use server-side Supabase client backed by Next.js cookies for SSR guards
- streamline OAuth callback redirect handling to honor redirect query param

## Testing
- pnpm --filter web lint *(fails: prompts for ESLint init configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dbe5a3d7988327b82c6d10a6e66214