### PR TITLE
Fix Supabase PKCE auth flow and callback handling

### DIFF
--- a/apps/web/app/auth/callback/page.tsx
+++ b/apps/web/app/auth/callback/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
+import type { Route } from "next";
 import { supaBrowser } from "@/lib/supabase-browser";
 import type { SupabaseClient } from "@supabase/supabase-js";
 export const dynamic = "force-dynamic";
@@ -19,21 +20,24 @@ function Inner() {
         const { error } = await sb.auth.exchangeCodeForSession(window.location.href);
         if (error) {
           console.error("PKCE exchange:", error);
-          return router.replace("/login?error=oauth");
+          return router.replace(("/login?error=oauth") as unknown as Route);
         }
       }
 
       const {
         data: { session },
       } = await sb.auth.getSession();
-      if (!session) return router.replace("/login");
+      if (!session) return router.replace("/login" as Route);
 
       await fetch("/api/auth/oauth-bootstrap", {
         method: "POST",
         headers: { Authorization: `Bearer ${session.access_token}` },
       }).catch(() => {});
 
-      router.replace(search.get("redirect") || "/dashboard");
+      const raw = search.get("redirect");
+      const to: Route =
+        raw && raw.startsWith("/") ? (raw as Route) : ("/dashboard" as Route);
+      router.replace(to);
     })();
   }, [router, search]);
 

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,9 +1,11 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-let _client: SupabaseClient | null = null;
+export type SupabaseBrowserClient = SupabaseClient;
 
-export function supaBrowser(): SupabaseClient {
+let _client: SupabaseBrowserClient | null = null;
+
+export function supaBrowser(): SupabaseBrowserClient {
   if (_client) return _client;
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL!;

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,7 +1,7 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-export type SupabaseBrowserClient = SupabaseClient;
+export type SupabaseBrowserClient = SupabaseClient<any, any, any>;
 
 let _client: SupabaseBrowserClient | null = null;
 
@@ -35,7 +35,7 @@ export function supaBrowser(): SupabaseBrowserClient {
         }`;
       },
     },
-  });
+  }) as unknown as SupabaseBrowserClient;
 
   return _client;
 }

--- a/apps/web/lib/supabase-server-ssr.ts
+++ b/apps/web/lib/supabase-server-ssr.ts
@@ -2,8 +2,8 @@ import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-export function supaServer(): SupabaseClient {
-  const c = cookies();
+export function supaServer(): SupabaseClient<any, any, any> {
+  const c = cookies() as any;
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
@@ -15,7 +15,7 @@ export function supaServer(): SupabaseClient {
           c.set({ name, value: "", ...options, maxAge: 0 }),
       },
     }
-  );
+  ) as unknown as SupabaseClient<any, any, any>;
 }
 
 export async function getServerUser() {

--- a/apps/web/lib/supabase-server-ssr.ts
+++ b/apps/web/lib/supabase-server-ssr.ts
@@ -1,13 +1,9 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
+import type { SupabaseClient } from "@supabase/supabase-js";
 
-export type SupabaseServerClient = ReturnType<typeof createServerClient>;
-
-export function supaServer(): SupabaseServerClient {
-  const c = cookies() as unknown as {
-    get: (name: string) => { value?: string } | undefined;
-    set: (options: { name: string; value: string } & Record<string, unknown>) => void;
-  };
+export function supaServer(): SupabaseClient {
+  const c = cookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,


### PR DESCRIPTION
## Summary
- switch the browser Supabase client to PKCE, persisting sessions via document cookies for SSR compatibility
- update the OAuth callback to exchange PKCE codes, respect redirect targets, and bootstrap the session before navigating
- align the SSR Supabase client with cookie-based auth helpers for consistent session reads

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dbff4fe8988327a2d5c108c195954d