### PR TITLE
Fix Supabase auth redirects for Google login

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -9,11 +9,12 @@ import LoginClient from "./_client";
 export default async function Page({
   searchParams,
 }: {
-  searchParams?: { redirect?: string };
+  searchParams: Promise<{ redirect?: string } | undefined>;
 }) {
+  const resolvedSearchParams = await searchParams;
   const user = await getServerUser();
   if (user) {
-    const raw = searchParams?.redirect;
+    const raw = resolvedSearchParams?.redirect;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : ("/dashboard" as Route);
     redirect(to);
   }

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -1,10 +1,21 @@
+export const dynamic = "force-dynamic";
+
 import { redirect } from "next/navigation";
+import type { Route } from "next";
 
 import { getServerUser } from "@/lib/supabase-server-ssr";
 import LoginClient from "./_client";
 
-export default async function Page() {
+export default async function Page({
+  searchParams,
+}: {
+  searchParams?: { redirect?: string };
+}) {
   const user = await getServerUser();
-  if (user) redirect("/dashboard");
+  if (user) {
+    const raw = searchParams?.redirect;
+    const to: Route = raw && raw.startsWith("/") ? (raw as Route) : ("/dashboard" as Route);
+    redirect(to);
+  }
   return <LoginClient />;
 }

--- a/apps/web/app/[locale]/sign-in/page.tsx
+++ b/apps/web/app/[locale]/sign-in/page.tsx
@@ -1,17 +1,25 @@
+export const dynamic = "force-dynamic";
+
 import { redirect } from "next/navigation";
+import type { Route } from "next";
 
 import { getServerUser } from "@/lib/supabase-server-ssr";
 import SignInClient from "./_client";
 
 export default async function Page({
   params,
+  searchParams,
 }: {
   params: Promise<{ locale: string }>;
+  searchParams?: { redirect?: string };
 }) {
   const { locale } = await params;
   const user = await getServerUser();
   if (user) {
-    redirect(`/${locale}/dashboard`);
+    const raw = searchParams?.redirect;
+    const fallback = `/${locale}/dashboard`;
+    const to: Route = raw && raw.startsWith("/") ? (raw as Route) : (fallback as Route);
+    redirect(to);
   }
   return <SignInClient />;
 }

--- a/apps/web/app/[locale]/sign-in/page.tsx
+++ b/apps/web/app/[locale]/sign-in/page.tsx
@@ -11,12 +11,13 @@ export default async function Page({
   searchParams,
 }: {
   params: Promise<{ locale: string }>;
-  searchParams?: { redirect?: string };
+  searchParams: Promise<{ redirect?: string } | undefined>;
 }) {
   const { locale } = await params;
+  const resolvedSearchParams = await searchParams;
   const user = await getServerUser();
   if (user) {
-    const raw = searchParams?.redirect;
+    const raw = resolvedSearchParams?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : (fallback as Route);
     redirect(to);

--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -11,12 +11,13 @@ export default async function Page({
   searchParams,
 }: {
   params: Promise<{ locale: string }>;
-  searchParams?: { redirect?: string };
+  searchParams: Promise<{ redirect?: string } | undefined>;
 }) {
   const { locale } = await params;
+  const resolvedSearchParams = await searchParams;
   const user = await getServerUser();
   if (user) {
-    const raw = searchParams?.redirect;
+    const raw = resolvedSearchParams?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : (fallback as Route);
     redirect(to);

--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -1,17 +1,25 @@
+export const dynamic = "force-dynamic";
+
 import { redirect } from "next/navigation";
+import type { Route } from "next";
 
 import { getServerUser } from "@/lib/supabase-server-ssr";
 import SignUpClient from "./_client";
 
 export default async function Page({
   params,
+  searchParams,
 }: {
   params: Promise<{ locale: string }>;
+  searchParams?: { redirect?: string };
 }) {
   const { locale } = await params;
   const user = await getServerUser();
   if (user) {
-    redirect(`/${locale}/dashboard`);
+    const raw = searchParams?.redirect;
+    const fallback = `/${locale}/dashboard`;
+    const to: Route = raw && raw.startsWith("/") ? (raw as Route) : (fallback as Route);
+    redirect(to);
   }
   return <SignUpClient />;
 }

--- a/apps/web/lib/supabase-server-ssr.ts
+++ b/apps/web/lib/supabase-server-ssr.ts
@@ -1,20 +1,29 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
+import type { CookieMethodsServerDeprecated } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-export function supaServer(): SupabaseClient {
-  const c = cookies();
+type SupabaseServerClient = SupabaseClient<any, any, any>;
+
+export function supaServer(): SupabaseServerClient {
+  const cookieStore = cookies();
+  const c = cookieStore as unknown as Awaited<ReturnType<typeof cookies>>;
+  const cookieMethods: CookieMethodsServerDeprecated = {
+    get: (name) => c.get(name)?.value,
+    set: (name, value, options) => {
+      c.set({ name, value, ...options });
+    },
+    remove: (name, options) => {
+      c.set({ name, value: "", ...options, maxAge: 0 });
+    },
+  };
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-      cookies: {
-        get: (name) => c.get(name)?.value,
-        set: (name, value, options) => c.set({ name, value, ...options }),
-        remove: (name, options) => c.set({ name, value: "", ...options, maxAge: 0 }),
-      },
+      cookies: cookieMethods,
     }
-  );
+  ) as SupabaseServerClient;
 }
 
 export async function getServerUser() {

--- a/apps/web/lib/supabase-server-ssr.ts
+++ b/apps/web/lib/supabase-server-ssr.ts
@@ -1,33 +1,20 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
-import type { CookieMethodsServerDeprecated } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-
-type SupabaseServerClient = SupabaseClient<any, any, any>;
-
-export function supaServer(): SupabaseServerClient {
-  const cookieStore = cookies();
-  const c = cookieStore as unknown as Awaited<ReturnType<typeof cookies>>;
-  const cookieMethods: CookieMethodsServerDeprecated = {
-    get: (name) => c.get(name)?.value,
-    set: (name, value, options) => {
-      c.set({ name, value, ...options });
-    },
-    remove: (name, options) => {
-      c.set({ name, value: "", ...options, maxAge: 0 });
-    },
-  };
-
+export function supaServer(): SupabaseClient {
+  const c = cookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-
-      cookies: cookieMethods,
+      cookies: {
+        get: (name) => c.get(name)?.value,
+        set: (name, value, options) => c.set({ name, value, ...options }),
+        remove: (name, options) => c.set({ name, value: "", ...options, maxAge: 0 }),
+      },
     }
-  ) as SupabaseServerClient;
-
+  );
 }
 
 export async function getServerUser() {

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,100 +1,10 @@
-import type { NextRequest } from "next/server";
 import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
 
-const SESSION_COOKIE_NAME = "umkm_session";
-const SESSION_SECRET = process.env.SESSION_SECRET ?? "";
-const SESSION_MIN_LENGTH = 32;
-
-function base64UrlToUint8Array(value: string) {
-  const normalized = value.replace(/-/g, "+").replace(/_/g, "/");
-  const padding = normalized.length % 4 === 0 ? "" : "=".repeat(4 - (normalized.length % 4));
-  const decoded = atob(normalized + padding);
-  const bytes = new Uint8Array(decoded.length);
-  for (let i = 0; i < decoded.length; i += 1) {
-    bytes[i] = decoded.charCodeAt(i);
-  }
-  return bytes;
-}
-
-function uint8ArrayToBase64Url(bytes: Uint8Array) {
-  let binary = "";
-  bytes.forEach((value) => {
-    binary += String.fromCharCode(value);
-  });
-  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
-}
-
-async function signPayload(payload: string) {
-  if (!SESSION_SECRET || SESSION_SECRET.length < SESSION_MIN_LENGTH) return null;
-  const encoder = new TextEncoder();
-  const key = await crypto.subtle.importKey(
-    "raw",
-    encoder.encode(SESSION_SECRET),
-    { name: "HMAC", hash: "SHA-256" },
-    false,
-    ["sign"]
-  );
-  const signature = await crypto.subtle.sign("HMAC", key, encoder.encode(payload));
-  return uint8ArrayToBase64Url(new Uint8Array(signature));
-}
-
-async function verifySession(token: string) {
-  const [encodedPayload, signature] = token.split(".");
-  if (!encodedPayload || !signature) return null;
-  const payloadBytes = base64UrlToUint8Array(encodedPayload);
-  const payloadJson = new TextDecoder().decode(payloadBytes);
-  const expectedSignature = await signPayload(payloadJson);
-  if (!expectedSignature || expectedSignature !== signature) {
-    return null;
-  }
-  try {
-    const payload = JSON.parse(payloadJson) as { verified?: boolean; exp?: number };
-    if (!payload.exp || payload.exp * 1000 < Date.now()) {
-      return null;
-    }
-    return payload;
-  } catch {
-    return null;
-  }
-}
-
-function isProtectedPath(pathname: string) {
-  return pathname.startsWith("/dashboard") || pathname.startsWith("/app");
-}
-
-function isAuthPath(pathname: string) {
-  return pathname.startsWith("/login") || pathname.startsWith("/otp");
-}
-
-export async function middleware(request: NextRequest) {
-  const { pathname } = request.nextUrl;
-
-  const sessionToken = request.cookies.get(SESSION_COOKIE_NAME)?.value;
-  const session = sessionToken ? await verifySession(sessionToken) : null;
-
-  if (isProtectedPath(pathname)) {
-    if (!session) {
-      const url = request.nextUrl.clone();
-      url.pathname = "/login";
-      url.searchParams.set("redirect", pathname);
-      return NextResponse.redirect(url);
-    }
-    if (!session.verified) {
-      const url = request.nextUrl.clone();
-      url.pathname = "/verify-email";
-      return NextResponse.redirect(url);
-    }
-  }
-
-  if (session && isAuthPath(pathname)) {
-    const url = request.nextUrl.clone();
-    url.pathname = "/dashboard";
-    return NextResponse.redirect(url);
-  }
-
+export function middleware(_request: NextRequest) {
   return NextResponse.next();
 }
 
 export const config = {
-  matcher: ["/dashboard/:path*", "/app/:path*", "/login", "/otp"]
+  matcher: [],
 };


### PR DESCRIPTION
## Summary
- update the Supabase SSR helper to rely on cookie-based sessions so server rendering sees the signed-in user
- force dynamic rendering for the login and sign-in/sign-up routes and honor redirect query parameters when a session already exists
- disable the legacy middleware redirect logic that conflicted with Supabase-managed sessions

## Testing
- pnpm --filter web lint *(fails: prompts for interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dccca065688327a3d8bc716132fd50