### PR TITLE
Fix SSR auth session handling and guards

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -9,12 +9,11 @@ import LoginClient from "./_client";
 export default async function Page({
   searchParams,
 }: {
-  searchParams: Promise<{ redirect?: string } | undefined>;
+  searchParams?: { redirect?: string };
 }) {
-  const resolvedSearchParams = await searchParams;
   const user = await getServerUser();
   if (user) {
-    const raw = resolvedSearchParams?.redirect;
+    const raw = searchParams?.redirect;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : ("/dashboard" as Route);
     redirect(to);
   }

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -9,11 +9,12 @@ import LoginClient from "./_client";
 export default async function Page({
   searchParams,
 }: {
-  searchParams?: { redirect?: string };
+  searchParams?: Promise<{ redirect?: string }>;
 }) {
   const user = await getServerUser();
   if (user) {
-    const raw = searchParams?.redirect;
+    const resolvedSearchParams = searchParams ? await searchParams : undefined;
+    const raw = resolvedSearchParams?.redirect;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : ("/dashboard" as Route);
     redirect(to);
   }

--- a/apps/web/app/[locale]/dashboard/page.tsx
+++ b/apps/web/app/[locale]/dashboard/page.tsx
@@ -8,9 +8,9 @@ export const dynamic = "force-dynamic";
 export default async function Page({
   params,
 }: {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }) {
-  const { locale } = params;
+  const { locale } = await params;
   const user = await getServerUser();
   if (!user) {
     redirect(`/login?redirect=/${locale}/dashboard`);

--- a/apps/web/app/[locale]/dashboard/page.tsx
+++ b/apps/web/app/[locale]/dashboard/page.tsx
@@ -8,9 +8,9 @@ export const dynamic = "force-dynamic";
 export default async function Page({
   params,
 }: {
-  params: Promise<{ locale: string }>;
+  params: { locale: string };
 }) {
-  const { locale } = await params;
+  const { locale } = params;
   const user = await getServerUser();
   if (!user) {
     redirect(`/login?redirect=/${locale}/dashboard`);

--- a/apps/web/app/[locale]/sign-in/page.tsx
+++ b/apps/web/app/[locale]/sign-in/page.tsx
@@ -10,13 +10,14 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: { locale: string };
-  searchParams?: { redirect?: string };
+  params: Promise<{ locale: string }>;
+  searchParams?: Promise<{ redirect?: string }>;
 }) {
-  const { locale } = params;
+  const { locale } = await params;
   const user = await getServerUser();
   if (user) {
-    const raw = searchParams?.redirect;
+    const resolvedSearchParams = searchParams ? await searchParams : undefined;
+    const raw = resolvedSearchParams?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : (fallback as Route);
     redirect(to);

--- a/apps/web/app/[locale]/sign-in/page.tsx
+++ b/apps/web/app/[locale]/sign-in/page.tsx
@@ -10,14 +10,13 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: Promise<{ locale: string }>;
-  searchParams: Promise<{ redirect?: string } | undefined>;
+  params: { locale: string };
+  searchParams?: { redirect?: string };
 }) {
-  const { locale } = await params;
-  const resolvedSearchParams = await searchParams;
+  const { locale } = params;
   const user = await getServerUser();
   if (user) {
-    const raw = resolvedSearchParams?.redirect;
+    const raw = searchParams?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : (fallback as Route);
     redirect(to);

--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -10,13 +10,14 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: { locale: string };
-  searchParams?: { redirect?: string };
+  params: Promise<{ locale: string }>;
+  searchParams?: Promise<{ redirect?: string }>;
 }) {
-  const { locale } = params;
+  const { locale } = await params;
   const user = await getServerUser();
   if (user) {
-    const raw = searchParams?.redirect;
+    const resolvedSearchParams = searchParams ? await searchParams : undefined;
+    const raw = resolvedSearchParams?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : (fallback as Route);
     redirect(to);

--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -10,14 +10,13 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: Promise<{ locale: string }>;
-  searchParams: Promise<{ redirect?: string } | undefined>;
+  params: { locale: string };
+  searchParams?: { redirect?: string };
 }) {
-  const { locale } = await params;
-  const resolvedSearchParams = await searchParams;
+  const { locale } = params;
   const user = await getServerUser();
   if (user) {
-    const raw = resolvedSearchParams?.redirect;
+    const raw = searchParams?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to: Route = raw && raw.startsWith("/") ? (raw as Route) : (fallback as Route);
     redirect(to);

--- a/apps/web/app/api/auth/session-sync/route.ts
+++ b/apps/web/app/api/auth/session-sync/route.ts
@@ -2,6 +2,7 @@ export const runtime = "nodejs";
 
 import { NextRequest, NextResponse } from "next/server";
 import { createServerClient } from "@supabase/ssr";
+import { cookies } from "next/headers";
 import { z } from "zod";
 
 const Body = z.object({
@@ -11,37 +12,27 @@ const Body = z.object({
 
 export async function POST(req: NextRequest) {
   const json = await req.json().catch(() => ({}));
-  const parsed = Body.safeParse(json);
-  if (!parsed.success) {
-    return NextResponse.json({ error: "Bad request" }, { status: 400 });
-  }
+  const p = Body.safeParse(json);
+  if (!p.success) return NextResponse.json({ error: "Bad request" }, { status: 400 });
 
-  const response = NextResponse.json({ ok: true });
+  const c = cookies();
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        getAll() {
-          return req.cookies.getAll();
-        },
-        setAll(cookies) {
-          cookies.forEach(({ name, value, options }) => {
-            response.cookies.set({ name, value, ...options });
-          });
-        },
+        get: (n) => c.get(n)?.value,
+        set: (n, v, o) => c.set({ name: n, value: v, ...o }),
+        remove: (n, o) => c.set({ name: n, value: "", ...o, maxAge: 0 }),
       },
     }
   );
 
   const { error } = await supabase.auth.setSession({
-    access_token: parsed.data.access_token,
-    refresh_token: parsed.data.refresh_token,
+    access_token: p.data.access_token,
+    refresh_token: p.data.refresh_token,
   });
-  if (error) {
-    console.error("[session-sync] setSession:", error.message || error);
-    return NextResponse.json({ error: "SET_SESSION_FAILED" }, { status: 500 });
-  }
+  if (error) return NextResponse.json({ error: "SET_SESSION_FAILED" }, { status: 500 });
 
-  return response;
+  return NextResponse.json({ ok: true });
 }

--- a/apps/web/app/api/auth/session-sync/route.ts
+++ b/apps/web/app/api/auth/session-sync/route.ts
@@ -15,15 +15,19 @@ export async function POST(req: NextRequest) {
   const p = Body.safeParse(json);
   if (!p.success) return NextResponse.json({ error: "Bad request" }, { status: 400 });
 
-  const c = cookies();
+  const c = await cookies();
   const supabase = createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get: (n) => c.get(n)?.value,
-        set: (n, v, o) => c.set({ name: n, value: v, ...o }),
-        remove: (n, o) => c.set({ name: n, value: "", ...o, maxAge: 0 }),
+        getAll: () =>
+          c.getAll().map((cookie) => ({ name: cookie.name, value: cookie.value })),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            c.set({ name, value, ...options });
+          });
+        },
       },
     }
   );

--- a/apps/web/app/dashboard/page.tsx
+++ b/apps/web/app/dashboard/page.tsx
@@ -1,0 +1,12 @@
+import { redirect } from "next/navigation";
+
+import { getServerUser } from "@/lib/supabase-server-ssr";
+import DashboardClient from "../[locale]/dashboard/_client";
+
+export const dynamic = "force-dynamic";
+
+export default async function Page() {
+  const user = await getServerUser();
+  if (!user) redirect("/login?redirect=/dashboard");
+  return <DashboardClient />;
+}

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,9 +1,13 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-let _client: SupabaseClient | null = null;
+type TypedSupabaseClient = SupabaseClient<any, any, any, any, any>;
 
-export function supaBrowser(): SupabaseClient {
+export type SupabaseBrowserClient = TypedSupabaseClient;
+
+let _client: TypedSupabaseClient | null = null;
+
+export function supaBrowser(): TypedSupabaseClient {
   if (_client) return _client;
   _client = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,

--- a/apps/web/lib/supabase-browser.ts
+++ b/apps/web/lib/supabase-browser.ts
@@ -1,18 +1,25 @@
 import { createBrowserClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-export type SupabaseBrowserClient = SupabaseClient<any, any, any>;
+let _client: SupabaseClient | null = null;
 
-let _client: SupabaseBrowserClient | null = null;
-
-export function supaBrowser(): SupabaseBrowserClient {
+export function supaBrowser(): SupabaseClient {
   if (_client) return _client;
   _client = createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    { auth: { flowType: "pkce", persistSession: true, detectSessionInUrl: true, autoRefreshToken: true } }
+    {
+      auth: {
+        flowType: "pkce",
+        persistSession: true,
+        detectSessionInUrl: true,
+        autoRefreshToken: true,
+      },
+    }
   );
   return _client;
 }
-export function resetSupaBrowserClient(){ _client = null; }
 
+export function resetSupaBrowserClient() {
+  _client = null;
+}

--- a/apps/web/lib/supabase-server-ssr.ts
+++ b/apps/web/lib/supabase-server-ssr.ts
@@ -2,23 +2,29 @@ import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-export function supaServer(): SupabaseClient {
-  const c = cookies();
+type TypedSupabaseClient = SupabaseClient<any, any, any, any, any>;
+
+export async function supaServer(): Promise<TypedSupabaseClient> {
+  const c = await cookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
       cookies: {
-        get: (n) => c.get(n)?.value,
-        set: (n, v, o) => c.set({ name: n, value: v, ...o }),
-        remove: (n, o) => c.set({ name: n, value: "", ...o, maxAge: 0 }),
+        getAll: () =>
+          c.getAll().map((cookie) => ({ name: cookie.name, value: cookie.value })),
+        setAll: (cookiesToSet) => {
+          cookiesToSet.forEach(({ name, value, options }) => {
+            c.set({ name, value, ...options });
+          });
+        },
       },
     }
   );
 }
 
 export async function getServerUser() {
-  const sb = supaServer();
+  const sb = await supaServer();
   const {
     data: { user },
   } = await sb.auth.getUser();

--- a/apps/web/lib/supabase-server-ssr.ts
+++ b/apps/web/lib/supabase-server-ssr.ts
@@ -1,29 +1,20 @@
 import { cookies } from "next/headers";
 import { createServerClient } from "@supabase/ssr";
-import type { CookieMethodsServerDeprecated } from "@supabase/ssr";
 import type { SupabaseClient } from "@supabase/supabase-js";
 
-type SupabaseServerClient = SupabaseClient<any, any, any>;
-
-export function supaServer(): SupabaseServerClient {
-  const cookieStore = cookies();
-  const c = cookieStore as unknown as Awaited<ReturnType<typeof cookies>>;
-  const cookieMethods: CookieMethodsServerDeprecated = {
-    get: (name) => c.get(name)?.value,
-    set: (name, value, options) => {
-      c.set({ name, value, ...options });
-    },
-    remove: (name, options) => {
-      c.set({ name, value: "", ...options, maxAge: 0 });
-    },
-  };
+export function supaServer(): SupabaseClient {
+  const c = cookies();
   return createServerClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-      cookies: cookieMethods,
+      cookies: {
+        get: (n) => c.get(n)?.value,
+        set: (n, v, o) => c.set({ name: n, value: v, ...o }),
+        remove: (n, o) => c.set({ name: n, value: "", ...o, maxAge: 0 }),
+      },
     }
-  ) as SupabaseServerClient;
+  );
 }
 
 export async function getServerUser() {


### PR DESCRIPTION
## Summary
- configure Supabase browser and server clients for PKCE and SSR cookie-based sessions
- update the OAuth callback/session-sync flow and add a default dashboard page protected by server guards
- guard login/sign-in/sign-up routes on the server and prevent OTP signup emails for existing users

## Testing
- pnpm lint *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dcd6062df883278dd170c2e3886e19