### PR TITLE
Refine locale auth flows

### DIFF
--- a/apps/web/app/[locale]/auth/login/_client.tsx
+++ b/apps/web/app/[locale]/auth/login/_client.tsx
@@ -13,7 +13,8 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { supaBrowser } from "@/lib/supabase-browser";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
 
-type RouterReplaceArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
+type RouterNavigateArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
+type RouterObjectArg = Extract<RouterNavigateArg, { pathname: string }>;
 
 const GoogleIcon = () => (
   <svg
@@ -74,8 +75,8 @@ export default function SignInPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const dashboardHref = useMemo(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } }) as const,
+  const dashboardHref = useMemo<RouterObjectArg>(
+    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } } as const),
     [resolvedLocale]
   );
   const forgotPasswordHref = useMemo(
@@ -113,7 +114,7 @@ export default function SignInPage() {
         setError(signInError.message || "Kredensial tidak valid.");
         return;
       }
-      router.replace(dashboardHref as unknown as RouterReplaceArg);
+      router.replace(dashboardHref);
     } catch (err) {
       if (typeof window !== "undefined") {
         console.error("[sign-in] Login error", err);

--- a/apps/web/app/[locale]/auth/login/page.tsx
+++ b/apps/web/app/[locale]/auth/login/page.tsx
@@ -9,17 +9,16 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: Promise<{ locale: string }>;
-  searchParams?: Promise<{ redirect?: string }>;
+  params: { locale: string };
+  searchParams?: { redirect?: string };
 }) {
-  const { locale } = await params;
+  const { locale } = params;
   const user = await getServerUser();
   if (user) {
-    const resolvedSearchParams = searchParams ? await searchParams : undefined;
-    const raw = resolvedSearchParams?.redirect;
+    const raw = searchParams?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to = raw && raw.startsWith("/") ? raw : fallback;
-    redirect(to as unknown as import("next").Route);
+    redirect(to);
   }
   return <SignInClient />;
 }

--- a/apps/web/app/[locale]/auth/signup/_client.tsx
+++ b/apps/web/app/[locale]/auth/signup/_client.tsx
@@ -19,7 +19,8 @@ import { supaBrowser } from "@/lib/supabase-browser";
 import { isAllowedGmail, isValidEmailFormat, normalizeEmail } from "@/lib/email";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
 
-type RouterReplaceArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
+type RouterNavigateArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
+type RouterObjectArg = Extract<RouterNavigateArg, { pathname: string }>;
 
 
 const GoogleIcon = () => (
@@ -95,8 +96,8 @@ export default function SignUpPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const dashboardHref = useMemo(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } }) as const,
+  const dashboardHref = useMemo<RouterObjectArg>(
+    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } } as const),
     [resolvedLocale]
   );
   const signInHref = useMemo(
@@ -254,7 +255,7 @@ export default function SignUpPage() {
           return;
         }
 
-        router.replace(dashboardHref as unknown as RouterReplaceArg);
+        router.replace(dashboardHref);
       } catch (err) {
         if (typeof window !== "undefined") {
           console.error("[sign-up] Register error", err);

--- a/apps/web/app/[locale]/auth/signup/page.tsx
+++ b/apps/web/app/[locale]/auth/signup/page.tsx
@@ -9,17 +9,16 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: Promise<{ locale: string }>;
-  searchParams?: Promise<{ redirect?: string }>;
+  params: { locale: string };
+  searchParams?: { redirect?: string };
 }) {
-  const { locale } = await params;
+  const { locale } = params;
   const user = await getServerUser();
   if (user) {
-    const resolvedSearchParams = searchParams ? await searchParams : undefined;
-    const raw = resolvedSearchParams?.redirect;
+    const raw = searchParams?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to = raw && raw.startsWith("/") ? raw : fallback;
-    redirect(to as unknown as import("next").Route);
+    redirect(to);
   }
   return <SignUpClient />;
 }

--- a/apps/web/app/[locale]/dashboard/page.tsx
+++ b/apps/web/app/[locale]/dashboard/page.tsx
@@ -8,12 +8,12 @@ export const dynamic = "force-dynamic";
 export default async function Page({
   params,
 }: {
-  params: Promise<{ locale: string }>;
+  params: { locale: string };
 }) {
-  const { locale } = await params;
+  const { locale } = params;
   const user = await getServerUser();
   if (!user) {
-    redirect(`/${locale}/auth/login?redirect=/${locale}/dashboard` as unknown as import("next").Route);
+    redirect(`/${locale}/auth/login?redirect=/${locale}/dashboard`);
   }
 
   const supabase = await supaServer();
@@ -45,7 +45,7 @@ export default async function Page({
   );
 
   if (!completed) {
-    redirect(`/${locale}/onboarding` as unknown as import("next").Route);
+    redirect(`/${locale}/onboarding`);
   }
 
   return <DashboardClient />;


### PR DESCRIPTION
## Summary
- redirect authenticated users away from login and signup based on locale-aware search params
- rebuild the locale OAuth callback to sync sessions server-side and bootstrap user data before redirecting
- enforce dashboard auth/onboarding guards while updating client navigations to typed locale routes

## Testing
- pnpm -C apps/web lint *(fails: command requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68dd4cda3fd083279c5135e41a1bebba