### PR TITLE
Fix auth callback handling and typed locale routes

### DIFF
--- a/apps/web/app/[locale]/auth/login/_client.tsx
+++ b/apps/web/app/[locale]/auth/login/_client.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import type { Route } from "next";
 import { AlertCircle, Loader2 } from "lucide-react";
 
 import { EmailField, PasswordField } from "@/components/auth/AuthFormParts";
@@ -12,9 +13,6 @@ import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { supaBrowser } from "@/lib/supabase-browser";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
-
-type RouterNavigateArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
-type RouterObjectArg = Extract<RouterNavigateArg, { pathname: string }>;
 
 const GoogleIcon = () => (
   <svg
@@ -75,20 +73,20 @@ export default function SignInPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const dashboardHref = useMemo<RouterObjectArg>(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } } as const),
+  const dashboardHref = useMemo<Route>(
+    () => (`/${resolvedLocale}/dashboard`) as Route,
     [resolvedLocale]
   );
-  const forgotPasswordHref = useMemo(
-    () => ({ pathname: "/[locale]/forgot-password", params: { locale: resolvedLocale } }) as const,
+  const forgotPasswordHref = useMemo<Route>(
+    () => (`/${resolvedLocale}/forgot-password`) as Route,
     [resolvedLocale]
   );
-  const signUpHref = useMemo(
-    () => ({ pathname: "/[locale]/auth/signup", params: { locale: resolvedLocale } }) as const,
+  const signUpHref = useMemo<Route>(
+    () => (`/${resolvedLocale}/auth/signup`) as Route,
     [resolvedLocale]
   );
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     setError(null);
 

--- a/apps/web/app/[locale]/auth/login/page.tsx
+++ b/apps/web/app/[locale]/auth/login/page.tsx
@@ -9,13 +9,14 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: { locale: string };
-  searchParams?: { redirect?: string };
+  params: Promise<{ locale: string }>;
+  searchParams?: Promise<{ redirect?: string }>;
 }) {
-  const { locale } = params;
+  const { locale } = await params;
+  const search = searchParams ? await searchParams : undefined;
   const user = await getServerUser();
   if (user) {
-    const raw = searchParams?.redirect;
+    const raw = search?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to = raw && raw.startsWith("/") ? raw : fallback;
     redirect(to);

--- a/apps/web/app/[locale]/auth/signup/_client.tsx
+++ b/apps/web/app/[locale]/auth/signup/_client.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from "react";
+import type { Route } from "next";
 import { AlertCircle, Loader2 } from "lucide-react";
 
 import {
@@ -18,9 +19,6 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { supaBrowser } from "@/lib/supabase-browser";
 import { isAllowedGmail, isValidEmailFormat, normalizeEmail } from "@/lib/email";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
-
-type RouterNavigateArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
-type RouterObjectArg = Extract<RouterNavigateArg, { pathname: string }>;
 
 
 const GoogleIcon = () => (
@@ -96,12 +94,12 @@ export default function SignUpPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const dashboardHref = useMemo<RouterObjectArg>(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } } as const),
+  const dashboardHref = useMemo<Route>(
+    () => (`/${resolvedLocale}/dashboard`) as Route,
     [resolvedLocale]
   );
-  const signInHref = useMemo(
-    () => ({ pathname: "/[locale]/auth/login", params: { locale: resolvedLocale } }) as const,
+  const signInHref = useMemo<Route>(
+    () => (`/${resolvedLocale}/auth/login`) as Route,
     [resolvedLocale]
   );
 
@@ -168,7 +166,7 @@ export default function SignUpPage() {
   }, [countdown, email, name, passwordValid, sendingCode]);
 
   const handleSubmit = useCallback(
-    async (event: React.FormEvent<HTMLFormElement>) => {
+    async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
       setError(null);
 

--- a/apps/web/app/[locale]/auth/signup/page.tsx
+++ b/apps/web/app/[locale]/auth/signup/page.tsx
@@ -9,13 +9,14 @@ export default async function Page({
   params,
   searchParams,
 }: {
-  params: { locale: string };
-  searchParams?: { redirect?: string };
+  params: Promise<{ locale: string }>;
+  searchParams?: Promise<{ redirect?: string }>;
 }) {
-  const { locale } = params;
+  const { locale } = await params;
+  const search = searchParams ? await searchParams : undefined;
   const user = await getServerUser();
   if (user) {
-    const raw = searchParams?.redirect;
+    const raw = search?.redirect;
     const fallback = `/${locale}/dashboard`;
     const to = raw && raw.startsWith("/") ? raw : fallback;
     redirect(to);

--- a/apps/web/app/[locale]/dashboard/page.tsx
+++ b/apps/web/app/[locale]/dashboard/page.tsx
@@ -8,9 +8,9 @@ export const dynamic = "force-dynamic";
 export default async function Page({
   params,
 }: {
-  params: { locale: string };
+  params: Promise<{ locale: string }>;
 }) {
-  const { locale } = params;
+  const { locale } = await params;
   const user = await getServerUser();
   if (!user) {
     redirect(`/${locale}/auth/login?redirect=/${locale}/dashboard`);


### PR DESCRIPTION
## Summary
- convert the locale-specific OAuth callback page into a client component that waits for Supabase PKCE sessions, syncs cookies, and redirects with locale-aware routes
- update the login and signup clients to use locale-based typed routes while keeping Google OAuth redirects targeting the locale callback
- adjust auth and dashboard server pages to use promise-based params/searchParams compatible with Next.js typed routes

## Testing
- CI=1 pnpm -C apps/web build
- pnpm -C apps/web dev

------
https://chatgpt.com/codex/tasks/task_e_68dd55aea9a083279de851cec91e8eb5