### PR TITLE
Fix locale-aware navigation helpers and redirects

### DIFF
--- a/apps/web/app/[locale]/auth/action/page.tsx
+++ b/apps/web/app/[locale]/auth/action/page.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { href, path } from "@/lib/locale-nav";
 import type { SupabaseBrowserClient } from "@/lib/supabase-browser";
 import { getSupabaseBrowserClient } from "@/lib/supabase-client";
 import { cn } from "@/lib/utils";
@@ -57,14 +58,8 @@ export default function AuthActionPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const loginHref = useMemo(
-    () => ({ pathname: "/[locale]/sign-in", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
-  const dashboardHref = useMemo(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
+  const loginHref = useMemo(() => href("/[locale]/sign-in", resolvedLocale), [resolvedLocale]);
+  const dashboardPath = useMemo(() => path("/[locale]/dashboard", resolvedLocale), [resolvedLocale]);
   useEffect(() => {
     if (typeof window === "undefined") return;
     setHashParams(new URLSearchParams(window.location.hash.replace(/^#/, "")));
@@ -308,7 +303,7 @@ export default function AuthActionPage() {
                   window.location.href = continueUrl;
                   return;
                 }
-                router.replace(dashboardHref as unknown as Parameters<typeof router.replace>[0]);
+                router.replace(dashboardPath);
               }}
             >
               Ke Dashboard

--- a/apps/web/app/[locale]/auth/callback/page.tsx
+++ b/apps/web/app/[locale]/auth/callback/page.tsx
@@ -3,10 +3,10 @@
 import { Suspense, useEffect } from "react";
 import { useRouter, useParams, useSearchParams } from "next/navigation";
 import { supaBrowser } from "@/lib/supabase-browser";
+import { path } from "@/lib/locale-nav";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Route } from "next";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
-
-type RouterReplaceArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
 
 export const dynamic = "force-dynamic"; // client-only, no prerender
 
@@ -50,7 +50,7 @@ function CallbackInner() {
       }
 
       if (!session) {
-        router.replace({ pathname: "/[locale]/sign-in", params: { locale } } as unknown as RouterReplaceArg);
+        router.replace(path("/[locale]/sign-in", locale));
         return;
       }
 
@@ -77,11 +77,11 @@ function CallbackInner() {
       // Tentukan target redirect
       const nextRaw = search.get("next");
       if (nextRaw && nextRaw.startsWith("/")) {
-        router.replace(nextRaw as unknown as RouterReplaceArg);
+        router.replace(nextRaw as Route);
         return;
       }
 
-      router.replace({ pathname: "/[locale]/dashboard", params: { locale } } as unknown as RouterReplaceArg);
+        router.replace(path("/[locale]/dashboard", locale));
   })();
   }, [router, search, params, locale]);
 

--- a/apps/web/app/[locale]/auth/login/_client.tsx
+++ b/apps/web/app/[locale]/auth/login/_client.tsx
@@ -11,6 +11,7 @@ import { Button } from "@/components/ui/button";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { supaBrowser } from "@/lib/supabase-browser";
+import { href, path } from "@/lib/locale-nav";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
 
 const GoogleIcon = () => (
@@ -72,18 +73,9 @@ export default function SignInPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const dashboardHref = useMemo(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
-  const forgotPasswordHref = useMemo(
-    () => ({ pathname: "/[locale]/forgot-password", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
-  const signUpHref = useMemo(
-    () => ({ pathname: "/[locale]/sign-up", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
+  const dashboardPath = useMemo(() => path("/[locale]/dashboard", resolvedLocale), [resolvedLocale]);
+  const forgotPasswordHref = useMemo(() => href("/[locale]/forgot-password", resolvedLocale), [resolvedLocale]);
+  const signUpHref = useMemo(() => href("/[locale]/sign-up", resolvedLocale), [resolvedLocale]);
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -111,7 +103,7 @@ export default function SignInPage() {
         setError(signInError.message || "Kredensial tidak valid.");
         return;
       }
-      router.replace(dashboardHref as unknown as RouterReplaceArg);
+      router.replace(dashboardPath);
     } catch (err) {
       if (typeof window !== "undefined") {
         console.error("[sign-in] Login error", err);
@@ -277,4 +269,3 @@ export default function SignInPage() {
     </div>
   );
 }
-type RouterReplaceArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];

--- a/apps/web/app/[locale]/auth/signup/_client.tsx
+++ b/apps/web/app/[locale]/auth/signup/_client.tsx
@@ -16,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { supaBrowser } from "@/lib/supabase-browser";
+import { href, path } from "@/lib/locale-nav";
 import { isAllowedGmail, isValidEmailFormat, normalizeEmail } from "@/lib/email";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
 
@@ -93,14 +94,8 @@ export default function SignUpPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const dashboardHref = useMemo(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
-  const signInHref = useMemo(
-    () => ({ pathname: "/[locale]/sign-in", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
+  const dashboardPath = useMemo(() => path("/[locale]/dashboard", resolvedLocale), [resolvedLocale]);
+  const signInHref = useMemo(() => href("/[locale]/sign-in", resolvedLocale), [resolvedLocale]);
 
   const handleSendCode = useCallback(async () => {
     if (sendingCode || countdown > 0) return;
@@ -252,7 +247,7 @@ export default function SignUpPage() {
           return;
         }
 
-        router.replace(dashboardHref as unknown as RouterReplaceArg);
+        router.replace(dashboardPath);
       } catch (err) {
         if (typeof window !== "undefined") {
           console.error("[sign-up] Register error", err);
@@ -267,7 +262,7 @@ export default function SignUpPage() {
         setLoading(false);
       }
     },
-    [configError, dashboardHref, email, name, otpCode, otpSent, password, passwordValid, router]
+    [configError, dashboardPath, email, name, otpCode, otpSent, password, passwordValid, router]
   );
 
   const handleGoogleSignIn = useCallback(async () => {
@@ -469,4 +464,3 @@ export default function SignUpPage() {
     </div>
   );
 }
-type RouterReplaceArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];

--- a/apps/web/app/[locale]/auth/update-password/UpdatePasswordClient.tsx
+++ b/apps/web/app/[locale]/auth/update-password/UpdatePasswordClient.tsx
@@ -4,9 +4,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 
 import { supaBrowser } from "@/lib/supabase-browser";
+import { path } from "@/lib/locale-nav";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
-
-type RouterReplaceArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
 
 export default function UpdatePasswordClient() {
   const params = useParams<{ locale?: string }>();
@@ -24,6 +23,8 @@ export default function UpdatePasswordClient() {
     return defaultLocale;
   }, [params?.locale]);
 
+  const signInPath = useMemo(() => path("/[locale]/sign-in", resolvedLocale), [resolvedLocale]);
+
   useEffect(() => {
     if (once.current) return;
     once.current = true;
@@ -38,11 +39,7 @@ export default function UpdatePasswordClient() {
       return;
     }
     setMsg("Berhasil. Mengarahkan...");
-    router.replace({
-      pathname: "/[locale]/sign-in",
-      params: { locale: resolvedLocale },
-      query: { reset: "ok" },
-    } as unknown as RouterReplaceArg);
+    router.replace(`${signInPath}?reset=ok`);
   };
 
   return (

--- a/apps/web/app/[locale]/dashboard/_client.tsx
+++ b/apps/web/app/[locale]/dashboard/_client.tsx
@@ -12,10 +12,9 @@ import { Button } from "@/components/ui/button";
 import { CardX, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { UploadDropzone } from "@/components/upload-dropzone";
+import { path } from "@/lib/locale-nav";
 import { getSupabaseBrowserClient } from "@/lib/supabase-client";
 import { defaultLocale, isValidLocale, type Locale } from "@/lib/i18n";
-
-type RouterReplaceArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
 
 interface JobItem {
   id: string;
@@ -62,10 +61,7 @@ export default function DashboardPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const dashboardHref = useMemo(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
+  const dashboardPath = useMemo(() => path("/[locale]/dashboard", resolvedLocale), [resolvedLocale]);
 
   const fetchProfile = useCallback(async () => {
     if (!user) {
@@ -168,9 +164,9 @@ export default function DashboardPage() {
     const flag = searchParams?.get("verification");
     if (flag === "check-email") {
       setShowVerificationNotice(true);
-      router.replace(dashboardHref as unknown as RouterReplaceArg, { scroll: false });
+      router.replace(dashboardPath, { scroll: false });
     }
-  }, [dashboardHref, router, searchParams]);
+  }, [dashboardPath, router, searchParams]);
 
   const handleOnboardingSave = async (answers: OnboardingAnswers) => {
     if (!user) return;

--- a/apps/web/app/[locale]/dashboard/page.tsx
+++ b/apps/web/app/[locale]/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
 
 import { getServerUser, supaServer } from "@/lib/supabase-server-ssr";
+import { path } from "@/lib/locale-nav";
 import DashboardClient from "./_client";
 
 export const dynamic = "force-dynamic";
@@ -14,7 +15,8 @@ export default async function Page({
   const user = await getServerUser();
   if (!user) {
     const search = new URLSearchParams({ redirect: `/${locale}/dashboard` });
-    redirect(`/${locale}/sign-in?${search.toString()}`);
+    const signInRoute = path("/[locale]/sign-in", locale);
+    redirect(`${signInRoute}?${search.toString()}`);
   }
 
   const supabase = await supaServer();
@@ -46,7 +48,7 @@ export default async function Page({
   );
 
   if (!completed) {
-    redirect(`/${locale}/onboarding`);
+    redirect(path("/[locale]/onboarding", locale));
   }
 
   return <DashboardClient />;

--- a/apps/web/app/[locale]/forgot-password/page.tsx
+++ b/apps/web/app/[locale]/forgot-password/page.tsx
@@ -9,6 +9,7 @@ import { EmailField } from "@/components/auth/AuthFormParts";
 import { Button } from "@/components/ui/button";
 import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { href } from "@/lib/locale-nav";
 import { clientEnvFlags } from "@/lib/env-flags-client";
 import {
   collectMissingSupabaseEnvKeys,
@@ -25,10 +26,7 @@ export default function ForgotPasswordPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const loginHref = useMemo(
-    () => ({ pathname: "/[locale]/sign-in", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
+  const loginHref = useMemo(() => href("/[locale]/sign-in", resolvedLocale), [resolvedLocale]);
   const [email, setEmail] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/apps/web/app/[locale]/onboarding/_client.tsx
+++ b/apps/web/app/[locale]/onboarding/_client.tsx
@@ -9,9 +9,8 @@ import { Button } from '@/components/ui/button';
 import { CardX } from '@/components/ui/cardx';
 import { Input } from '@/components/ui/input';
 import { CreditBadge } from '@/components/credit-badge';
+import { path } from '@/lib/locale-nav';
 import { defaultLocale, isValidLocale, type Locale } from '@/lib/i18n';
-
-type RouterReplaceArg = Parameters<ReturnType<typeof useRouter>["replace"]>[0];
 
 export default function OnboardingPage() {
   const router = useRouter();
@@ -26,10 +25,7 @@ export default function OnboardingPage() {
     }
     return defaultLocale;
   }, [locale]);
-  const dashboardHref = useMemo(
-    () => ({ pathname: '/[locale]/dashboard', params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
+  const dashboardPath = useMemo(() => path('/[locale]/dashboard', resolvedLocale), [resolvedLocale]);
 
   const handleComplete = useCallback(async () => {
     if (saving) return;
@@ -39,12 +35,12 @@ export default function OnboardingPage() {
       if (!response.ok) {
         throw new Error('Failed to complete onboarding');
       }
-      router.replace(dashboardHref as unknown as RouterReplaceArg);
+      router.replace(dashboardPath);
     } catch (error) {
       console.error('[onboarding] Failed to complete onboarding', error);
       setSaving(false);
     }
-  }, [dashboardHref, router, saving]);
+  }, [dashboardPath, router, saving]);
 
   return (
     <div className="mx-auto max-w-3xl space-y-8">

--- a/apps/web/app/[locale]/page.tsx
+++ b/apps/web/app/[locale]/page.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import { ArrowRight } from 'lucide-react';
 import { getTranslations } from 'next-intl/server';
+
 import {
   BeforeAfterNoSSR,
   FeatureGridNoSSR,
@@ -9,13 +10,14 @@ import {
 } from '@/components/no-ssr';
 import { SectionHeading } from '@/components/SectionHeading';
 import { Button } from '@/components/ui/button';
+import { href } from '@/lib/locale-nav';
 import { defaultLocale, isValidLocale, type Locale } from '@/lib/i18n';
 
 export default async function LocaleLanding({ params }: { params: Promise<{ locale: string }> }) {
   const { locale: rawLocale } = await params;
   const locale: Locale = isValidLocale(rawLocale) ? (rawLocale as Locale) : defaultLocale;
-  const signUpHref = { pathname: '/[locale]/sign-up', params: { locale } } as const;
-  const editorHref = { pathname: '/[locale]/editor', params: { locale } } as const;
+  const signUpHref = href('/[locale]/sign-up', locale);
+  const editorHref = href('/[locale]/editor', locale);
   const t = await getTranslations({ locale, namespace: 'common' });
 
   return (

--- a/apps/web/app/[locale]/sign-in/page.tsx
+++ b/apps/web/app/[locale]/sign-in/page.tsx
@@ -1,9 +1,9 @@
 export const dynamic = "force-dynamic";
 
 import { redirect } from "next/navigation";
-import type { Route } from "next";
 
 import { getServerUser } from "@/lib/supabase-server-ssr";
+import { path } from "@/lib/locale-nav";
 import SignInClient from "../auth/login/_client";
 
 export default async function Page({
@@ -19,11 +19,8 @@ export default async function Page({
 
   if (user) {
     const redirectParam = search?.redirect;
-    const fallback = (`/${locale}/dashboard`) as Route;
-    const destination =
-      redirectParam && redirectParam.startsWith("/")
-        ? (redirectParam as Route)
-        : fallback;
+    const fallback = path("/[locale]/dashboard", locale);
+    const destination = redirectParam && redirectParam.startsWith("/") ? redirectParam : fallback;
 
     redirect(destination);
   }

--- a/apps/web/app/[locale]/sign-up/page.tsx
+++ b/apps/web/app/[locale]/sign-up/page.tsx
@@ -1,9 +1,9 @@
 export const dynamic = "force-dynamic";
 
 import { redirect } from "next/navigation";
-import type { Route } from "next";
 
 import { getServerUser } from "@/lib/supabase-server-ssr";
+import { path } from "@/lib/locale-nav";
 import SignUpClient from "../auth/signup/_client";
 
 export default async function Page({
@@ -19,11 +19,8 @@ export default async function Page({
 
   if (user) {
     const redirectParam = search?.redirect;
-    const fallback = (`/${locale}/dashboard`) as Route;
-    const destination =
-      redirectParam && redirectParam.startsWith("/")
-        ? (redirectParam as Route)
-        : fallback;
+    const fallback = path("/[locale]/dashboard", locale);
+    const destination = redirectParam && redirectParam.startsWith("/") ? redirectParam : fallback;
 
     redirect(destination);
   }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import dynamic from 'next/dynamic';
 import { ArrowRight } from 'lucide-react';
+
+import { href } from '@/lib/locale-nav';
 import { BeforeAfterNoSSR, FeatureGridNoSSR, FooterNoSSR, NavbarNoSSR, PricingSectionNoSSR } from '@/components/no-ssr';
 const HeroInteractiveImage = dynamic(
   () => import('@/components/HeroInteractiveImage'),
@@ -19,8 +21,8 @@ import { defaultLocale, type Locale } from '@/lib/i18n';
 
 export default function MarketingPage() {
   const locale: Locale = defaultLocale;
-  const signUpHref = { pathname: '/[locale]/sign-up', params: { locale } } as const;
-  const editorHref = { pathname: '/[locale]/editor', params: { locale } } as const;
+  const signUpHref = href('/[locale]/sign-up', locale);
+  const editorHref = href('/[locale]/editor', locale);
 
   return (
     <div className="relative min-h-screen overflow-hidden bg-background text-white">

--- a/apps/web/src/components/Navbar.tsx
+++ b/apps/web/src/components/Navbar.tsx
@@ -5,6 +5,8 @@ import { useParams, usePathname } from "next/navigation";
 import { useEffect, useMemo, useState } from "react";
 import { Menu, Sparkles } from "lucide-react";
 import { motion, useScroll } from "framer-motion";
+
+import { href } from "@/lib/locale-nav";
 import { Button } from "@/components/ui/button";
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetTrigger } from "@/components/ui/sheet";
 import { LangToggle } from "@/components/lang-toggle";
@@ -29,9 +31,7 @@ export function Navbar({ locale = "id", showSections }: { locale?: Locale; showS
   const fallbackLocale = locale ?? defaultLocale;
   const resolvedLocale = localeFromParams ?? fallbackLocale;
   const basePathString = localeFromParams ? `/${localeFromParams}` : "/";
-  const baseHref = localeFromParams
-    ? ({ pathname: "/[locale]", params: { locale: localeFromParams } }) as const
-    : "/";
+  const baseHref = localeFromParams ? href("/[locale]", localeFromParams) : "/";
   const showMarketing = showSections ?? (pathname === "/" || pathname === basePathString);
   const [active, setActive] = useState("home");
 
@@ -65,15 +65,12 @@ export function Navbar({ locale = "id", showSections }: { locale?: Locale; showS
 
   const navItems = useMemo(() => (showMarketing ? NAV_SECTIONS : []), [showMarketing]);
   const dashboardPathname = `/${resolvedLocale}/dashboard`;
-  const dashboardHref = useMemo(
-    () => ({ pathname: "/[locale]/dashboard", params: { locale: resolvedLocale } }) as const,
-    [resolvedLocale]
-  );
+  const dashboardHref = useMemo(() => href("/[locale]/dashboard", resolvedLocale), [resolvedLocale]);
   const brandHref = pathname?.startsWith(dashboardPathname) ? dashboardHref : baseHref;
   const marketingHref = useMemo(() => {
     if (localeFromParams) {
       return (id: (typeof NAV_SECTIONS)[number]["id"]) =>
-        ({ pathname: "/[locale]", params: { locale: localeFromParams }, hash: id }) as const;
+        ({ ...href("/[locale]", localeFromParams), hash: id }) as const;
     }
     return (id: (typeof NAV_SECTIONS)[number]["id"]) => ({ pathname: "/", hash: id }) as const;
   }, [localeFromParams]);

--- a/apps/web/src/components/auth/AuthNav.tsx
+++ b/apps/web/src/components/auth/AuthNav.tsx
@@ -4,6 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
 import type { Session } from "@supabase/supabase-js";
 import { useParams, usePathname } from "next/navigation";
+import { href } from "@/lib/locale-nav";
 import { cn } from "@/lib/utils";
 import { defaultLocale, isValidLocale } from "@/lib/i18n";
 import type { Locale } from "@/lib/i18n";
@@ -38,27 +39,9 @@ export default function AuthNav({
   const activeLocale = locale && isValidLocale(locale) ? (locale as Locale) : fallbackLocale;
   const fallback = defaultLocale;
   const finalLocale: Locale = activeLocale ?? fallback;
-  const dashboardHref = useMemo(
-    () => ({
-      pathname: "/[locale]/dashboard",
-      params: { locale: finalLocale }
-    }) as const,
-    [finalLocale]
-  );
-  const signInHref = useMemo(
-    () => ({
-      pathname: "/[locale]/sign-in",
-      params: { locale: finalLocale }
-    }) as const,
-    [finalLocale]
-  );
-  const signUpHref = useMemo(
-    () => ({
-      pathname: "/[locale]/sign-up",
-      params: { locale: finalLocale }
-    }) as const,
-    [finalLocale]
-  );
+  const dashboardHref = useMemo(() => href("/[locale]/dashboard", finalLocale), [finalLocale]);
+  const signInHref = useMemo(() => href("/[locale]/sign-in", finalLocale), [finalLocale]);
+  const signUpHref = useMemo(() => href("/[locale]/sign-up", finalLocale), [finalLocale]);
   const dashboardPathname = `/${finalLocale}/dashboard`;
 
   useEffect(() => {

--- a/apps/web/src/components/lang-toggle.tsx
+++ b/apps/web/src/components/lang-toggle.tsx
@@ -3,6 +3,8 @@
 import Link from 'next/link';
 import { useMemo } from 'react';
 import { usePathname } from 'next/navigation';
+
+import { href } from '@/lib/locale-nav';
 import { Button } from '@/components/ui/button';
 import { defaultLocale, isValidLocale, type Locale } from '@/lib/i18n';
 
@@ -20,27 +22,27 @@ function buildTargetHref(pathname: string | null | undefined, locale: Locale) {
   const rest = hasLocale ? segments.slice(1) : segments;
 
   if (rest.length === 0) {
-    return { pathname: '/[locale]', params: { locale } } as const;
+    return href('/[locale]', locale);
   }
 
   if (rest.length === 1) {
     switch (rest[0]) {
       case 'dashboard':
-        return { pathname: '/[locale]/dashboard', params: { locale } } as const;
+        return href('/[locale]/dashboard', locale);
       case 'editor':
-        return { pathname: '/[locale]/editor', params: { locale } } as const;
+        return href('/[locale]/editor', locale);
       case 'onboarding':
-        return { pathname: '/[locale]/onboarding', params: { locale } } as const;
+        return href('/[locale]/onboarding', locale);
       case 'gallery':
-        return { pathname: '/[locale]/gallery', params: { locale } } as const;
+        return href('/[locale]/gallery', locale);
       case 'forgot-password':
-        return { pathname: '/[locale]/forgot-password', params: { locale } } as const;
+        return href('/[locale]/forgot-password', locale);
       case 'sign-in':
-        return { pathname: '/[locale]/sign-in', params: { locale } } as const;
+        return href('/[locale]/sign-in', locale);
       case 'sign-up':
-        return { pathname: '/[locale]/sign-up', params: { locale } } as const;
+        return href('/[locale]/sign-up', locale);
       default:
-        return { pathname: '/[locale]', params: { locale } } as const;
+        return href('/[locale]', locale);
     }
   }
 
@@ -48,17 +50,17 @@ function buildTargetHref(pathname: string | null | undefined, locale: Locale) {
     const segment = rest[1];
     switch (segment) {
       case 'callback':
-        return { pathname: '/[locale]/auth/callback', params: { locale } } as const;
+        return href('/[locale]/auth/callback', locale);
       case 'action':
-        return { pathname: '/[locale]/auth/action', params: { locale } } as const;
+        return href('/[locale]/auth/action', locale);
       case 'update-password':
-        return { pathname: '/[locale]/auth/update-password', params: { locale } } as const;
+        return href('/[locale]/auth/update-password', locale);
       default:
-        return { pathname: '/[locale]/auth/callback', params: { locale } } as const;
+        return href('/[locale]/auth/callback', locale);
     }
   }
 
-  return { pathname: '/[locale]', params: { locale } } as const;
+  return href('/[locale]', locale);
 }
 
 export function LangToggle() {

--- a/apps/web/src/lib/locale-nav.ts
+++ b/apps/web/src/lib/locale-nav.ts
@@ -1,0 +1,9 @@
+import type { Route } from "next";
+
+export function href<P extends string>(pathname: P, locale: string) {
+  return { pathname: path(pathname, locale) } as const;
+}
+
+export function path(pathname: string, locale: string): Route {
+  return (`/${locale}${pathname.replace("/[locale]", "")}` as unknown) as Route;
+}


### PR DESCRIPTION
## Summary
- add a locale navigation helper to build Link href objects and string paths
- update navigation components and marketing pages to use helper-generated locale-aware hrefs
- refactor auth and onboarding flows to redirect with real locale paths instead of /[locale]

## Testing
- `CI=1 pnpm -C apps/web build`


------
https://chatgpt.com/codex/tasks/task_e_68ddf972f58483278916a4345af769ea