### PR TITLE
feat: move onboarding to dashboard modal and persist answers

### DIFF
--- a/apps/web/app/[locale]/auth/callback/page.tsx
+++ b/apps/web/app/[locale]/auth/callback/page.tsx
@@ -81,8 +81,8 @@ function CallbackInner() {
         return;
       }
 
-        router.replace(path("/[locale]/dashboard", locale));
-  })();
+      router.replace(path("/[locale]/dashboard", locale));
+    })();
   }, [router, search, params, locale]);
 
   return (

--- a/apps/web/app/[locale]/onboarding/page.tsx
+++ b/apps/web/app/[locale]/onboarding/page.tsx
@@ -1,7 +1,6 @@
 import { redirect } from "next/navigation";
 
-import { getServerUser, supaServer } from "@/lib/supabase-server-ssr";
-import OnboardingClient from "./_client";
+import { path } from "@/lib/locale-nav";
 
 export default async function Page({
   params,
@@ -9,42 +8,5 @@ export default async function Page({
   params: Promise<{ locale: string }>;
 }) {
   const { locale } = await params;
-  const user = await getServerUser();
-  if (!user) {
-    const search = new URLSearchParams({ redirect: `/${locale}/onboarding` });
-    redirect(`/${locale}/sign-in?${search.toString()}`);
-  }
-
-  const supabase = await supaServer();
-  const { data, error } = await supabase
-    .from("profiles")
-    .select("onboarding_completed,has_onboarded,onboarding")
-    .eq("user_id", user.id)
-    .maybeSingle();
-
-  let profile = data as
-    | ({ onboarding_completed?: boolean | null; has_onboarded?: boolean | null; onboarding?: boolean | null } | null)
-    | null;
-
-  if (error) {
-    if (error.code === "42703") {
-      const fallback = await supabase.from("profiles").select("*").eq("user_id", user.id).maybeSingle();
-      if (!fallback.error) {
-        profile = fallback.data as typeof profile;
-      }
-    } else if (error.code !== "42P01") {
-      console.warn("[onboarding] Failed to load profile", error);
-    }
-  }
-
-  const completed = Boolean(
-    profile &&
-      (profile.onboarding_completed === true || profile.has_onboarded === true || profile.onboarding === true)
-  );
-
-  if (completed) {
-    redirect(`/${locale}/dashboard`);
-  }
-
-  return <OnboardingClient />;
+  redirect(path("/[locale]/dashboard", locale));
 }

--- a/apps/web/app/api/profile/onboarding/reset/route.ts
+++ b/apps/web/app/api/profile/onboarding/reset/route.ts
@@ -1,0 +1,26 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+
+import { supaServer } from "@/lib/supabase-server-ssr";
+
+export async function POST() {
+  const sb = await supaServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { error } = await sb
+    .from("profiles")
+    .update({ onboarding_completed: false, onboarding_answers: null })
+    .eq("user_id", user.id);
+
+  if (error) {
+    return NextResponse.json({ error: "DB_ERROR" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/profile/onboarding/save/route.ts
+++ b/apps/web/app/api/profile/onboarding/save/route.ts
@@ -1,0 +1,47 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { supaServer } from "@/lib/supabase-server-ssr";
+
+const Payload = z.object({
+  answers: z.object({
+    usage_type: z.enum(["personal", "team"]),
+    purpose: z.string().min(1),
+    business_type: z.string().min(1),
+    ref_source: z.enum(["friend", "search", "ad", "other"]),
+    other_note: z.string().optional(),
+  }),
+});
+
+export async function POST(req: Request) {
+  const sb = await supaServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => null);
+  const parsed = Payload.safeParse(json);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Bad request" }, { status: 400 });
+  }
+
+  const { error } = await sb
+    .from("profiles")
+    .update({
+      onboarding_completed: true,
+      onboarding_answers: parsed.data.answers,
+      onboarding_updated_at: new Date().toISOString(),
+    })
+    .eq("user_id", user.id);
+
+  if (error) {
+    return NextResponse.json({ error: "DB_ERROR" }, { status: 500 });
+  }
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/src/components/lang-toggle.tsx
+++ b/apps/web/src/components/lang-toggle.tsx
@@ -32,7 +32,7 @@ function buildTargetHref(pathname: string | null | undefined, locale: Locale) {
       case 'editor':
         return href('/[locale]/editor', locale);
       case 'onboarding':
-        return href('/[locale]/onboarding', locale);
+        return href('/[locale]/dashboard', locale);
       case 'gallery':
         return href('/[locale]/gallery', locale);
       case 'forgot-password':

--- a/apps/web/supabase.sql
+++ b/apps/web/supabase.sql
@@ -16,3 +16,8 @@ create table if not exists public.email_otps (
 create index if not exists email_otps_email_idx on public.email_otps (email);
 create index if not exists email_otps_consumed_idx on public.email_otps (consumed);
 create index if not exists email_otps_expires_at_idx on public.email_otps (expires_at);
+
+alter table if exists public.profiles
+  add column if not exists onboarding_completed boolean not null default false,
+  add column if not exists onboarding_answers jsonb,
+  add column if not exists onboarding_updated_at timestamptz;


### PR DESCRIPTION
## Summary
- load profile onboarding status on the dashboard server component and pass it to the client instead of redirecting to the onboarding page
- update the dashboard client and onboarding modal to capture the new answer schema, call the save API, and only hide the modal when answers are stored
- add onboarding save/reset API endpoints and extend the Supabase profile schema; make auxiliary navigation and callback flows point back to the dashboard

## Testing
- pnpm -C apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68de02b4fff08327a3fbe83be6440a9f