### PR TITLE
Fix onboarding select to use stable option values

### DIFF
--- a/apps/web/app/api/profile/onboarding/save/route.ts
+++ b/apps/web/app/api/profile/onboarding/save/route.ts
@@ -3,14 +3,15 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 
+import { SOURCE_VALUES, PURPOSE_VALUES } from "@/lib/onboarding-options";
 import { supaServer } from "@/lib/supabase-server-ssr";
 
 const Payload = z.object({
   answers: z.object({
     usage_type: z.enum(["personal", "team"]),
-    purpose: z.string().min(1),
+    purpose: z.enum(PURPOSE_VALUES),
     business_type: z.string().min(1),
-    ref_source: z.enum(["friend", "search", "ad", "other"]),
+    ref_source: z.enum(SOURCE_VALUES),
     other_note: z.string().optional(),
   }),
 });

--- a/apps/web/src/lib/onboarding-options.ts
+++ b/apps/web/src/lib/onboarding-options.ts
@@ -1,0 +1,27 @@
+export const PURPOSES = [
+  { value: "sell_more", label: "Meningkatkan penjualan" },
+  { value: "brand_build", label: "Membangun brand" },
+  { value: "content_auto", label: "Otomasi konten" },
+  { value: "other", label: "Lainnya" },
+] as const;
+
+export type OnboardingPurpose = (typeof PURPOSES)[number]["value"];
+
+export const PURPOSE_VALUES = PURPOSES.map((option) => option.value) as [
+  OnboardingPurpose,
+  ...OnboardingPurpose[]
+];
+
+export const SOURCES = [
+  { value: "friend", label: "Teman" },
+  { value: "search", label: "Pencarian (Google, dsb.)" },
+  { value: "ads", label: "Iklan" },
+  { value: "other", label: "Lainnya" },
+] as const;
+
+export type OnboardingRefSource = (typeof SOURCES)[number]["value"];
+
+export const SOURCE_VALUES = SOURCES.map((option) => option.value) as [
+  OnboardingRefSource,
+  ...OnboardingRefSource[]
+];


### PR DESCRIPTION
## Summary
- centralize onboarding purpose and source options with stable keys for the onboarding flow
- update the onboarding modal to control selects with stable option keys, show matching labels, and convert legacy saved values
- validate onboarding submissions against the new stable option keys when saving via the API

## Testing
- pnpm --filter web lint *(fails: Next.js prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68de11615d2083279dbe4baa4a1a5354