### PR TITLE
Fix onboarding selects to use RHF controllers

### DIFF
--- a/apps/web/src/components/onboarding/OnboardingModal.tsx
+++ b/apps/web/src/components/onboarding/OnboardingModal.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { Controller, useForm } from "react-hook-form";
 import { Loader2 } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -75,18 +76,73 @@ const BUSINESS_TYPES = [
   "Elektronik",
 ];
 
+type OnboardingForm = {
+  usage_type: OnboardingAnswers["usage_type"];
+  purpose: string;
+  business_type: string;
+  ref_source: string;
+  other_note?: string;
+};
+
+const resolvePurpose = (value?: string | null): OnboardingPurpose | "" => {
+  if (!value) return "";
+  const normalized = value.trim().toLowerCase();
+  const direct = PURPOSES.find((option) => option.value === value);
+  if (direct) {
+    return direct.value;
+  }
+  const byLabel = PURPOSES.find((option) => option.label.toLowerCase() === normalized);
+  if (byLabel) {
+    return byLabel.value;
+  }
+  return LEGACY_PURPOSE_MAP[normalized] ?? "";
+};
+
+const resolveSource = (value?: string | null): OnboardingRefSource | "" => {
+  if (!value) return "";
+  const normalized = value.trim().toLowerCase();
+  const direct = SOURCES.find((option) => option.value === value);
+  if (direct) {
+    return direct.value;
+  }
+  const byLabel = SOURCES.find((option) => option.label.toLowerCase() === normalized);
+  if (byLabel) {
+    return byLabel.value;
+  }
+  return LEGACY_SOURCE_MAP[normalized] ?? "";
+};
+
 export function OnboardingModal({ open, defaultValues, onSave, onSkip }: OnboardingModalProps) {
-  const [usageType, setUsageType] = useState<OnboardingAnswers["usage_type"]>(
-    defaultValues?.usage_type ?? "personal"
-  );
-  const [purpose, setPurpose] = useState<OnboardingPurpose | "">(
-    defaultValues?.purpose ?? ""
-  );
-  const [industry, setIndustry] = useState<string>(defaultValues?.business_type ?? "");
-  const [source, setSource] = useState<OnboardingRefSource | "">(defaultValues?.ref_source ?? "");
-  const [otherNote, setOtherNote] = useState<string>(defaultValues?.other_note ?? "");
   const [status, setStatus] = useState<"idle" | "saving" | "skipping">("idle");
   const [error, setError] = useState<string | null>(null);
+  const resolvedPurpose = useMemo(
+    () => resolvePurpose(defaultValues?.purpose ?? null),
+    [defaultValues?.purpose]
+  );
+  const resolvedSource = useMemo(
+    () => resolveSource(defaultValues?.ref_source ?? null),
+    [defaultValues?.ref_source]
+  );
+  const defaultUsageType = defaultValues?.usage_type ?? "personal";
+  const defaultBusiness = defaultValues?.business_type ?? "";
+  const defaultOtherNote = defaultValues?.other_note ?? "";
+
+  const form = useForm<OnboardingForm>({
+    defaultValues: {
+      usage_type: defaultUsageType,
+      purpose: resolvedPurpose,
+      business_type: defaultBusiness,
+      ref_source: resolvedSource,
+      other_note: defaultOtherNote,
+    },
+    mode: "onChange",
+  });
+
+  const usageType = form.watch("usage_type");
+  const purpose = form.watch("purpose") ?? "";
+  const industry = form.watch("business_type") ?? "";
+  const source = form.watch("ref_source") ?? "";
+  const otherNote = form.watch("other_note") ?? "";
 
   const isValid = useMemo(() => {
     return Boolean(purpose && industry.trim() && source);
@@ -94,41 +150,23 @@ export function OnboardingModal({ open, defaultValues, onSave, onSkip }: Onboard
 
   useEffect(() => {
     if (!open) return;
-    const resolvePurpose = (value?: string | null): OnboardingPurpose | "" => {
-      if (!value) return "";
-      const normalized = value.trim().toLowerCase();
-      const direct = PURPOSES.find((option) => option.value === value);
-      if (direct) {
-        return direct.value;
-      }
-      const byLabel = PURPOSES.find((option) => option.label.toLowerCase() === normalized);
-      if (byLabel) {
-        return byLabel.value;
-      }
-      return LEGACY_PURPOSE_MAP[normalized] ?? "";
-    };
-
-    const resolveSource = (value?: string | null): OnboardingRefSource | "" => {
-      if (!value) return "";
-      const normalized = value.trim().toLowerCase();
-      const direct = SOURCES.find((option) => option.value === value);
-      if (direct) {
-        return direct.value;
-      }
-      const byLabel = SOURCES.find((option) => option.label.toLowerCase() === normalized);
-      if (byLabel) {
-        return byLabel.value;
-      }
-      return LEGACY_SOURCE_MAP[normalized] ?? "";
-    };
-
-    setUsageType(defaultValues?.usage_type ?? "personal");
-    setPurpose(resolvePurpose(defaultValues?.purpose));
-    setIndustry(defaultValues?.business_type ?? "");
-    setSource(resolveSource(defaultValues?.ref_source));
-    setOtherNote(defaultValues?.other_note ?? "");
+    form.reset({
+      usage_type: defaultUsageType,
+      purpose: resolvedPurpose,
+      business_type: defaultBusiness,
+      ref_source: resolvedSource,
+      other_note: defaultOtherNote,
+    });
     setError(null);
-  }, [defaultValues, open]);
+  }, [
+    open,
+    defaultUsageType,
+    resolvedPurpose,
+    defaultBusiness,
+    resolvedSource,
+    defaultOtherNote,
+    form,
+  ]);
 
   useEffect(() => {
     setError(null);
@@ -138,30 +176,34 @@ export function OnboardingModal({ open, defaultValues, onSave, onSkip }: Onboard
   const isSkipping = status === "skipping";
   const isBusy = status !== "idle";
 
-  const handleSubmit = async () => {
-    if (!isValid) {
+  const onSubmit = form.handleSubmit(
+    async (values) => {
+      if (!values.purpose || !values.ref_source || !values.business_type.trim()) {
+        setError("Lengkapi semua bidang wajib terlebih dahulu.");
+        return;
+      }
+
+      setStatus("saving");
+      setError(null);
+      try {
+        const trimmedOther = (values.other_note ?? "").trim();
+        await onSave({
+          usage_type: values.usage_type,
+          purpose: values.purpose as OnboardingPurpose,
+          business_type: values.business_type.trim(),
+          ref_source: values.ref_source as OnboardingRefSource,
+          other_note: trimmedOther ? trimmedOther : undefined,
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : "Gagal menyimpan jawaban.");
+      } finally {
+        setStatus("idle");
+      }
+    },
+    () => {
       setError("Lengkapi semua bidang wajib terlebih dahulu.");
-      return;
     }
-    setStatus("saving");
-    setError(null);
-    try {
-      const trimmedOther = otherNote.trim();
-      const selectedPurpose = purpose as OnboardingPurpose;
-      const selectedSource = source as OnboardingRefSource;
-      await onSave({
-        usage_type: usageType,
-        purpose: selectedPurpose,
-        business_type: industry.trim(),
-        ref_source: selectedSource,
-        other_note: trimmedOther ? trimmedOther : undefined,
-      });
-    } catch (err) {
-      setError(err instanceof Error ? err.message : "Gagal menyimpan jawaban.");
-    } finally {
-      setStatus("idle");
-    }
-  };
+  );
 
   const handleSkip = async () => {
     setStatus("skipping");
@@ -178,126 +220,157 @@ export function OnboardingModal({ open, defaultValues, onSave, onSkip }: Onboard
   return (
     <Dialog open={open}>
       <DialogContent hideClose className="max-w-2xl space-y-6">
-        <DialogHeader>
-          <DialogTitle>Kenalan dulu yuk!</DialogTitle>
-          <DialogDescription>
-            Jawaban kamu membantu kami menyesuaikan rekomendasi template dan otomasi konten.
-          </DialogDescription>
-        </DialogHeader>
-        <div className="grid gap-4">
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">Tipe pengguna</p>
-            <div className="flex gap-3">
-              {USER_TYPES.map((option) => (
-                <Button
-                  key={option.value}
-                  type="button"
-                  variant={usageType === option.value ? "primary" : "secondary"}
-                  onClick={() => setUsageType(option.value)}
-                  className={cn(
-                    "flex-1 border border-border/60",
-                    usageType === option.value ? "shadow-glow" : "bg-background/40"
-                  )}
-                >
-                  {option.label}
-                </Button>
-              ))}
-            </div>
-          </div>
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">Tujuan utama pakai UMKM Kits</p>
-            <Select
-              value={purpose}
-              onValueChange={(value) => setPurpose(value as OnboardingPurpose)}
-            >
-              <SelectTrigger className="text-white placeholder:text-muted-foreground">
-                <SelectValue placeholder="Pilih tujuan" />
-              </SelectTrigger>
-              <SelectContent className="text-foreground">
-                {PURPOSES.map((option) => (
-                  <SelectItem key={option.value} value={option.value} className="text-foreground">
-                    {option.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">Jenis usaha</p>
-            <div>
-              <Input
-                list="onboarding-business"
-                value={industry}
-                onChange={(event) => setIndustry(event.target.value)}
-                placeholder="Contoh: Kuliner"
-                className="text-white placeholder:text-muted-foreground"
-              />
-              <datalist id="onboarding-business">
-                {BUSINESS_TYPES.map((item) => (
-                  <option value={item} key={item} />
-                ))}
-              </datalist>
-            </div>
-          </div>
-          <div className="space-y-2">
-            <p className="text-sm font-medium text-foreground">Dari mana tahu UMKM Kits Studio?</p>
-            <Select
-              value={source}
-              onValueChange={(value) => setSource(value as OnboardingRefSource)}
-            >
-              <SelectTrigger className="text-white placeholder:text-muted-foreground">
-                <SelectValue placeholder="Pilih sumber" />
-              </SelectTrigger>
-              <SelectContent className="text-foreground">
-                {SOURCES.map((item) => (
-                  <SelectItem key={item.value} value={item.value} className="text-foreground">
-                    {item.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-          {source === "other" ? (
+        <form onSubmit={onSubmit} className="space-y-6">
+          <DialogHeader>
+            <DialogTitle>Kenalan dulu yuk!</DialogTitle>
+            <DialogDescription>
+              Jawaban kamu membantu kami menyesuaikan rekomendasi template dan otomasi konten.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4">
             <div className="space-y-2">
-              <p className="text-sm font-medium text-foreground">Ceritakan lebih lanjut (opsional)</p>
-              <Input
-                value={otherNote}
-                onChange={(event) => setOtherNote(event.target.value)}
-                placeholder="Tulis detail tambahan"
-                className="text-white placeholder:text-muted-foreground"
+              <p className="text-sm font-medium text-foreground">Tipe pengguna</p>
+              <div className="flex gap-3">
+                {USER_TYPES.map((option) => (
+                  <Button
+                    key={option.value}
+                    type="button"
+                    variant={usageType === option.value ? "primary" : "secondary"}
+                    onClick={() =>
+                      form.setValue("usage_type", option.value, {
+                        shouldDirty: true,
+                        shouldTouch: true,
+                      })
+                    }
+                    className={cn(
+                      "flex-1 border border-border/60",
+                      usageType === option.value ? "shadow-glow" : "bg-background/40"
+                    )}
+                  >
+                    {option.label}
+                  </Button>
+                ))}
+              </div>
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Tujuan utama pakai UMKM Kits</p>
+              <Controller
+                name="purpose"
+                control={form.control}
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <Select value={field.value || ""} onValueChange={field.onChange}>
+                    <SelectTrigger
+                      ref={field.ref}
+                      onBlur={field.onBlur}
+                      className="text-white placeholder:text-muted-foreground"
+                    >
+                      <SelectValue placeholder="Pilih tujuan" />
+                    </SelectTrigger>
+                    <SelectContent className="text-foreground">
+                      {PURPOSES.map((option) => (
+                        <SelectItem
+                          key={option.value}
+                          value={option.value}
+                          className="text-foreground"
+                        >
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
               />
             </div>
-          ) : null}
-          {error ? <p className="text-sm text-destructive">{error}</p> : null}
-        </div>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <Button
-            type="button"
-            variant="ghost"
-            className="text-sm text-muted-foreground hover:text-foreground"
-            onClick={handleSkip}
-            disabled={isBusy}
-          >
-            {isSkipping ? (
-              <span className="flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                Memproses...
-              </span>
-            ) : (
-              "Lewati dulu"
-            )}
-          </Button>
-          <Button type="button" onClick={handleSubmit} disabled={!isValid || isBusy}>
-            {isSaving ? (
-              <span className="flex items-center gap-2">
-                <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
-                Menyimpan...
-              </span>
-            ) : (
-              "Simpan jawaban"
-            )}
-          </Button>
-        </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Jenis usaha</p>
+              <div>
+                <Input
+                  list="onboarding-business"
+                  placeholder="Contoh: Kuliner"
+                  className="text-white placeholder:text-muted-foreground"
+                  {...form.register("business_type", {
+                    validate: (value) => value.trim().length > 0,
+                  })}
+                />
+                <datalist id="onboarding-business">
+                  {BUSINESS_TYPES.map((item) => (
+                    <option value={item} key={item} />
+                  ))}
+                </datalist>
+              </div>
+            </div>
+            <div className="space-y-2">
+              <p className="text-sm font-medium text-foreground">Dari mana tahu UMKM Kits Studio?</p>
+              <Controller
+                name="ref_source"
+                control={form.control}
+                rules={{ required: true }}
+                render={({ field }) => (
+                  <Select value={field.value || ""} onValueChange={field.onChange}>
+                    <SelectTrigger
+                      ref={field.ref}
+                      onBlur={field.onBlur}
+                      className="text-white placeholder:text-muted-foreground"
+                    >
+                      <SelectValue placeholder="Pilih sumber" />
+                    </SelectTrigger>
+                    <SelectContent className="text-foreground">
+                      {SOURCES.map((item) => (
+                        <SelectItem
+                          key={item.value}
+                          value={item.value}
+                          className="text-foreground"
+                        >
+                          {item.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                )}
+              />
+            </div>
+            {source === "other" ? (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-foreground">Ceritakan lebih lanjut (opsional)</p>
+                <Input
+                  placeholder="Tulis detail tambahan"
+                  className="text-white placeholder:text-muted-foreground"
+                  {...form.register("other_note")}
+                />
+              </div>
+            ) : null}
+            {error ? <p className="text-sm text-destructive">{error}</p> : null}
+          </div>
+          <div className="flex flex-wrap items-center justify-between gap-3">
+            <Button
+              type="button"
+              variant="ghost"
+              className="text-sm text-muted-foreground hover:text-foreground"
+              onClick={handleSkip}
+              disabled={isBusy}
+            >
+              {isSkipping ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  Memproses...
+                </span>
+              ) : (
+                "Lewati dulu"
+              )}
+            </Button>
+            <Button type="submit" disabled={!isValid || isBusy}>
+              {isSaving ? (
+                <span className="flex items-center gap-2">
+                  <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+                  Menyimpan...
+                </span>
+              ) : (
+                "Simpan jawaban"
+              )}
+            </Button>
+          </div>
+        </form>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- bind the onboarding modal selects through react-hook-form controllers so they store the stable option keys
- normalize legacy default answers and reset the form state whenever the modal reopens to keep select values in sync
- wire the remaining inputs into the shared form instance and keep validation/error handling in one place

## Testing
- pnpm lint *(fails: prompts to configure ESLint)*

------
https://chatgpt.com/codex/tasks/task_e_68de171d60c08327b5cf1fc37fab2e7d