### PR TITLE
Add react-hook-form dependency to fix onboarding build failure

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -32,6 +32,7 @@
     "next-intl": "^3.15.2",
     "posthog-js": "^1.210.1",
     "react": "19.0.0-rc-66855b96-20241106",
+    "react-hook-form": "^7.53.0",
     "react-compare-slider": "^3.1.0",
     "react-dom": "19.0.0-rc-66855b96-20241106",
     "react-dropzone": "^14.2.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       react-dropzone:
         specifier: ^14.2.3
         version: 14.3.8(react@19.0.0-rc-66855b96-20241106)
+      react-hook-form:
+        specifier: ^7.53.0
+        version: 7.63.0(react@19.0.0-rc-66855b96-20241106)
       react-rnd:
         specifier: ^10.4.2
         version: 10.5.2(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
@@ -3254,6 +3257,12 @@ packages:
     engines: {node: '>= 10.13'}
     peerDependencies:
       react: '>= 16.8 || 18.0.0'
+
+  react-hook-form@7.63.0:
+    resolution: {integrity: sha512-ZwueDMvUeucovM2VjkCf7zIHcs1aAlDimZu2Hvel5C5907gUzMpm4xCrQXtRzCvsBqFjonB4m3x4LzCFI1ZKWA==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17 || ^18 || ^19
 
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
@@ -7596,6 +7605,10 @@ snapshots:
       attr-accept: 2.2.5
       file-selector: 2.1.2
       prop-types: 15.8.1
+      react: 19.0.0-rc-66855b96-20241106
+
+  react-hook-form@7.63.0(react@19.0.0-rc-66855b96-20241106):
+    dependencies:
       react: 19.0.0-rc-66855b96-20241106
 
   react-is@16.13.1: {}


### PR DESCRIPTION
## Summary
- add the missing `react-hook-form` dependency required by the onboarding modal component
- update the workspace lockfile after installing the new package

## Testing
- pnpm -C apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68de1a3e8b588327a70d433d133855f9