### PR TITLE
feat: redesign dashboard with Supabase-driven stats and tools

### DIFF
--- a/apps/web/app/[locale]/dashboard/DashboardClient.tsx
+++ b/apps/web/app/[locale]/dashboard/DashboardClient.tsx
@@ -1,7 +1,17 @@
 "use client";
 
+import { useMemo } from "react";
 import Image from "next/image";
 import Link from "next/link";
+
+const placeholderCover = "/images/dashboard-placeholder.svg";
+
+const toolLinks = [
+  { label: "Caption AI", pathname: "/[locale]/caption" },
+  { label: "Gambar AI", pathname: "/[locale]/image" },
+  { label: "Editor", pathname: "/[locale]/editor" },
+  { label: "Galeri", pathname: "/[locale]/gallery" },
+] as const;
 
 type Profile = {
   plan: string | null;
@@ -26,15 +36,6 @@ type Project = {
   updated_at: string;
 };
 
-const placeholderCover = "/images/dashboard-placeholder.svg";
-
-const toolLinks = [
-  { label: "Caption AI", pathname: "/[locale]/caption" },
-  { label: "Gambar AI", pathname: "/[locale]/image" },
-  { label: "Editor", pathname: "/[locale]/editor" },
-  { label: "Galeri", pathname: "/[locale]/gallery" },
-] as const;
-
 type DashboardClientProps = {
   locale: string;
   profile: Profile;
@@ -52,96 +53,144 @@ export default function DashboardClient({
   history,
   projects,
 }: DashboardClientProps) {
-  const planLabel =
-    profile?.plan === "pro"
-      ? "Paket Profesional"
-      : profile?.plan === "basic"
-        ? "Paket Basic"
-        : "Free Plan";
+  const topupHref = useMemo(
+    () => ({ pathname: "/[locale]/billing/topup", params: { locale } } as const),
+    [locale]
+  );
+  const editorHref = useMemo(
+    () => ({ pathname: "/[locale]/editor", params: { locale } } as const),
+    [locale]
+  );
 
-  const planExpires = profile?.plan_expires_at ? new Date(profile.plan_expires_at) : null;
-  const trialExpires = profile?.trial_expires_at ? new Date(profile.trial_expires_at) : null;
-  const daysLeft = trialExpires
-    ? Math.max(0, Math.ceil((trialExpires.getTime() - Date.now()) / 86_400_000))
-    : 0;
+  const planLabel = mapPlanLabel(profile?.plan);
+  const creditsValue = typeof profile?.credits === "number" ? profile.credits : 0;
+  const mondayJobs = jobsThisWeek ?? 0;
+  const usedCredits = totalUsed ?? 0;
+  const trialCredits = typeof profile?.trial_credits === "number" ? profile.trial_credits : 0;
+
+  const trialDaysLeft = (() => {
+    if (!profile?.trial_expires_at) return 0;
+    const expires = new Date(profile.trial_expires_at);
+    const diff = expires.getTime() - Date.now();
+    if (Number.isNaN(diff)) return 0;
+    return Math.max(0, Math.ceil(diff / 86_400_000));
+  })();
+
+  const numberFormatter = useMemo(() => new Intl.NumberFormat(locale), [locale]);
 
   return (
-    <div className="space-y-6 px-6 py-6">
-      <div>
-        <h1 className="text-2xl font-extrabold text-white">Dasboard AI Anda</h1>
-        <p className="text-sm text-gray-400">Pantau penggunaan kredit, kelola project dan pekerjaan AI anda.</p>
-      </div>
+    <div className="space-y-8 px-6 py-8">
+      <header className="space-y-2">
+        <p className="text-sm text-gray-400">Selamat datang kembali</p>
+        <h1 className="text-3xl font-bold text-white">
+          Dasbor AI Anda{profile?.full_name ? `, ${profile.full_name}` : ""}
+        </h1>
+        <p className="text-sm text-gray-400">
+          Pantau kredit, kelola project terbaru, dan akses alat AI favorit Anda.
+        </p>
+      </header>
 
-      <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-        <div className="space-y-3 rounded-xl border border-white/10 bg-[#10141C] p-5">
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-3">
+        <article className="rounded-2xl border border-white/10 bg-[#10141C] p-6 shadow-sm shadow-black/20">
           <div className="text-sm text-gray-400">Kredit aktif</div>
-          <div className="text-4xl font-extrabold text-white">{profile?.credits ?? 0}</div>
-          <div className="text-xs text-gray-300">
-            <span className="rounded bg-blue-900/40 px-2 py-1 text-blue-200">{planLabel}</span>
-            {planExpires ? (
-              <span className="ml-2 text-gray-400">Kedaluwarsa pada {planExpires.toLocaleDateString(locale)}</span>
-            ) : null}
+          <div className="mt-2 text-4xl font-extrabold text-white">
+            {numberFormatter.format(creditsValue)}
           </div>
-          <div className="mt-3 flex flex-wrap items-center gap-3 text-xs">
-            <div className="rounded-full bg-[#0B1220] px-3 py-2 font-semibold text-white">
-              FREE CREDITS <span className="ml-1 font-normal">{profile?.trial_credits ?? 0}</span>
-            </div>
-            <div className="rounded-full bg-[#0B1220] px-3 py-2 text-white">
-              <span className="font-semibold">{daysLeft}</span>
-              <span className="ml-1 text-gray-400">Days Left</span>
-            </div>
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-xs text-gray-300">
+            <span className="rounded-full bg-[#182033] px-3 py-1 font-semibold text-blue-100">{planLabel}</span>
+            <span className="rounded-full bg-[#0B1220] px-4 py-1 font-semibold text-white">
+              FREE CREDITS {numberFormatter.format(trialCredits)}
+              <span className="ml-2 text-xs font-normal text-gray-400">
+                / {trialDaysLeft} Days Left
+              </span>
+            </span>
           </div>
-        </div>
+          {profile?.plan_expires_at ? (
+            <p className="mt-3 text-xs text-gray-500">
+              Paket aktif hingga {new Date(profile.plan_expires_at).toLocaleDateString(locale)}
+            </p>
+          ) : null}
+        </article>
 
-        <div className="space-y-3 rounded-xl border border-white/10 bg-[#10141C] p-5">
-          <div className="text-sm text-gray-400">Pekerjaan minggu ini :</div>
-          <div className="text-4xl font-extrabold text-white">{jobsThisWeek}</div>
-          <p className="text-xs text-gray-400">Ringkasan otomatis dari pekerjaan AI anda.</p>
-        </div>
+        <article className="rounded-2xl border border-white/10 bg-[#10141C] p-6 shadow-sm shadow-black/20">
+          <div className="text-sm text-gray-400">Job AI minggu ini</div>
+          <div className="mt-2 text-4xl font-extrabold text-white">
+            {numberFormatter.format(mondayJobs)}
+          </div>
+          <p className="mt-3 text-xs text-gray-400">
+            Total tugas AI yang Anda jalankan sejak Senin.
+          </p>
+        </article>
 
-        <div className="relative space-y-3 rounded-xl border border-white/10 bg-[#10141C] p-5">
-          <div className="text-sm text-gray-400">Total kredit terpakai :</div>
-          <div className="text-4xl font-extrabold text-white">{totalUsed}</div>
+        <article className="relative rounded-2xl border border-white/10 bg-[#10141C] p-6 shadow-sm shadow-black/20">
+          <div className="text-sm text-gray-400">Kredit terpakai</div>
+          <div className="mt-2 text-4xl font-extrabold text-white">
+            {numberFormatter.format(usedCredits)}
+          </div>
           <Link
-            href={{ pathname: "/[locale]/billing/topup", params: { locale } } as any}
-            className="absolute right-4 top-4 rounded-full bg-blue-900 px-4 py-1 text-sm font-semibold text-blue-100"
+            href={topupHref}
+            className="absolute right-6 top-6 rounded-full bg-[#1E3A8A] px-4 py-1 text-xs font-semibold text-blue-100 transition hover:bg-[#2749b3]"
           >
             TOPUP
           </Link>
-        </div>
-      </div>
+          <p className="mt-3 text-xs text-gray-400">
+            Ringkasan kredit yang telah digunakan untuk seluruh alat.
+          </p>
+        </article>
+      </section>
 
-      <div className="grid grid-cols-1 gap-5 lg:grid-cols-[1fr_360px]">
-        <section className="rounded-xl border border-white/10 bg-[#10141C] p-5">
-          <div className="mb-4 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-white">Project anda</h2>
-            <span className="text-xs text-gray-500">{projects.length} aktif</span>
+      <section className="grid grid-cols-1 gap-6 lg:grid-cols-[1fr_360px]">
+        <article className="rounded-2xl border border-white/10 bg-[#10141C] p-6 shadow-sm shadow-black/20">
+          <div className="mb-5 flex flex-wrap items-center justify-between gap-3">
+            <div>
+              <h2 className="text-lg font-semibold text-white">Project anda</h2>
+              <p className="text-xs text-gray-500">Tiga project terbaru Anda.</p>
+            </div>
+            <span className="rounded-full bg-[#0B1220] px-3 py-1 text-xs font-medium text-gray-300">
+              {projects.length} aktif
+            </span>
           </div>
+
           {projects.length > 0 ? (
             <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
               {projects.map((project) => {
-                const cover = project.cover_url && project.cover_url.trim().length > 0 ? project.cover_url : placeholderCover;
+                const cover = project.cover_url?.trim() ? project.cover_url : placeholderCover;
+                const formattedDate = new Date(project.updated_at).toLocaleDateString(locale, {
+                  day: "2-digit",
+                  month: "short",
+                });
+
                 return (
-                  <div key={project.id} className="rounded-xl border border-white/10 bg-[#0C1118] p-3">
-                    <div className="relative aspect-[4/3] overflow-hidden rounded-lg">
+                  <div
+                    key={project.id}
+                    className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-[#0C1118] p-4"
+                  >
+                    <div className="relative aspect-[4/3] overflow-hidden rounded-xl bg-[#111827]">
                       <Image
                         src={cover}
                         alt={project.title}
                         fill
-                        sizes="(min-width: 640px) 30vw, 100vw"
                         className="object-cover"
+                        sizes="(min-width: 1024px) 25vw, (min-width: 640px) 33vw, 100vw"
+                        priority={false}
                       />
                     </div>
-                    <div className="mt-2 truncate font-medium text-white" title={project.title}>
-                      {project.title}
+                    <div>
+                      <p className="truncate text-sm font-semibold text-white" title={project.title}>
+                        {project.title}
+                      </p>
+                      <p className="text-xs text-gray-500">Terakhir diperbarui {formattedDate}</p>
                     </div>
-                    <div className="mt-2 flex gap-2">
-                      <button className="rounded-full border border-white/20 px-3 py-1 text-xs text-white/90 transition hover:bg-white/10">
+                    <div className="mt-auto flex items-center gap-2">
+                      <button
+                        type="button"
+                        className="flex-1 rounded-full border border-white/20 px-3 py-1 text-xs font-semibold text-white/80 transition hover:bg-white/10"
+                      >
                         BAGIKAN
                       </button>
                       <Link
-                        href={{ pathname: "/[locale]/editor", params: { locale } } as any}
-                        className="rounded-full border border-white/20 px-3 py-1 text-xs text-white/90 transition hover:bg-white/10"
+                        href={editorHref}
+                        className="flex-1 rounded-full border border-white/20 px-3 py-1 text-center text-xs font-semibold text-white transition hover:bg-white/10"
                       >
                         BUKA EDITOR
                       </Link>
@@ -151,64 +200,94 @@ export default function DashboardClient({
               })}
             </div>
           ) : (
-            <div className="rounded-xl border border-dashed border-white/10 bg-[#0C1118]/60 p-6 text-center text-sm text-gray-400">
+            <div className="rounded-2xl border border-dashed border-white/10 bg-[#0C1118]/60 p-8 text-center text-sm text-gray-400">
               Belum ada project. Mulai dari Editor untuk membuat project pertama Anda.
             </div>
           )}
-        </section>
+        </article>
 
-        <aside className="rounded-xl border border-white/10 bg-[#10141C] p-5">
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-white">Riwayat Credits</h2>
-            <div className="grid h-7 w-7 place-items-center rounded-full bg-[#0B1220] text-sm text-white">{history.length}</div>
+        <aside className="rounded-2xl border border-white/10 bg-[#10141C] p-6 shadow-sm shadow-black/20">
+          <div className="mb-5 flex items-center justify-between">
+            <div>
+              <h2 className="text-lg font-semibold text-white">Riwayat Credits</h2>
+              <p className="text-xs text-gray-500">10 transaksi terbaru.</p>
+            </div>
+            <span className="grid h-8 w-8 place-items-center rounded-full bg-[#0B1220] text-xs font-semibold text-white">
+              {history.length}
+            </span>
           </div>
+
           {history.length > 0 ? (
-            <div className="divide-y divide-white/10">
+            <ul className="divide-y divide-white/10">
               {history.map((item) => {
                 const createdAt = new Date(item.created_at);
-                const formattedTime = createdAt.toLocaleTimeString(locale, { hour: "2-digit", minute: "2-digit" });
-                const formattedDate = createdAt.toLocaleDateString(locale, {
+                const time = createdAt.toLocaleTimeString(locale, {
+                  hour: "2-digit",
+                  minute: "2-digit",
+                });
+                const date = createdAt.toLocaleDateString(locale, {
                   day: "2-digit",
                   month: "short",
                   year: "numeric",
                 });
-                const amountLabel = item.amount >= 0 ? `+${item.amount}` : `${item.amount}`;
-                const amountClass = item.amount >= 0 ? "text-emerald-400" : "text-red-400";
+                const amount = item.amount ?? 0;
+                const positive = amount >= 0;
+
                 return (
-                  <div key={item.id} className="flex items-center justify-between py-3">
+                  <li key={item.id} className="flex items-center justify-between py-3">
                     <div>
-                      <div className="text-sm text-white">{item.reason}</div>
-                      <div className="text-xs text-gray-400">
-                        {formattedTime} · {formattedDate}
-                      </div>
+                      <p className="text-sm font-medium text-white">{item.reason}</p>
+                      <p className="text-xs text-gray-500">
+                        {time} · {date}
+                      </p>
                     </div>
-                    <div className={`text-sm font-semibold ${amountClass}`}>{amountLabel}</div>
-                  </div>
+                    <span
+                      className={`text-sm font-semibold ${positive ? "text-emerald-400" : "text-red-400"}`}
+                    >
+                      {positive
+                        ? `+${numberFormatter.format(Math.abs(amount))}`
+                        : `-${numberFormatter.format(Math.abs(amount))}`}
+                    </span>
+                  </li>
                 );
               })}
-            </div>
+            </ul>
           ) : (
-            <div className="rounded-xl border border-dashed border-white/10 bg-[#0C1118]/60 p-6 text-center text-sm text-gray-400">
+            <div className="rounded-2xl border border-dashed border-white/10 bg-[#0C1118]/60 p-8 text-center text-sm text-gray-400">
               Belum ada transaksi kredit.
             </div>
           )}
         </aside>
-      </div>
+      </section>
 
-      <section className="rounded-xl border border-white/10 bg-[#10141C] p-5">
-        <h2 className="mb-4 text-lg font-semibold text-white">Alat</h2>
-        <div className="grid grid-cols-2 gap-4 sm:grid-cols-4">
-          {toolLinks.map((tool) => (
-            <Link
-              key={tool.label}
-              href={{ pathname: tool.pathname, params: { locale } } as any}
-              className="rounded-full bg-[#0B1220] px-5 py-3 text-center text-sm font-semibold text-white transition hover:bg-[#12203A]"
-            >
-              {tool.label}
-            </Link>
-          ))}
+      <section className="rounded-2xl border border-white/10 bg-[#10141C] p-6 shadow-sm shadow-black/20">
+        <div className="mb-4 flex flex-col gap-1">
+          <h2 className="text-lg font-semibold text-white">Alat</h2>
+          <p className="text-xs text-gray-500">Pintasan ke tools yang paling sering digunakan.</p>
+        </div>
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {toolLinks.map((tool) => {
+            const href = { pathname: tool.pathname, params: { locale } } as const;
+            return (
+              <Link
+                key={tool.label}
+                href={href}
+                className="rounded-full bg-[#0B1220] px-5 py-3 text-center text-sm font-semibold text-white transition hover:bg-[#162647]"
+              >
+                {tool.label}
+              </Link>
+            );
+          })}
         </div>
       </section>
     </div>
   );
+}
+
+function mapPlanLabel(plan: string | null | undefined) {
+  if (!plan) return "Free Plan";
+  const normalized = plan.toLowerCase();
+  if (normalized === "basic") return "Basic";
+  if (normalized === "pro") return "Pro";
+  return plan;
 }


### PR DESCRIPTION
## Summary
- update the dashboard server page to enforce localized auth redirect and gather profile, usage, history, and project data from Supabase
- rebuild the DashboardClient with the new stat cards, projects grid, credit history panel, and tools bar while using typed routes
- ensure credit usage aggregation and formatting for the new UI while keeping legacy sections removed

## Testing
- pnpm -C apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68de4224cb64832785e5acbc9a633dd6