### PR TITLE
fix(dashboard): wire Supabase SSR data & onboarding gating; ensure profile upsert; add onboarding save API; no-cache page

### DIFF
--- a/apps/web/app/api/_diag/sb/route.ts
+++ b/apps/web/app/api/_diag/sb/route.ts
@@ -1,0 +1,18 @@
+export const runtime = "nodejs";
+import { NextResponse } from "next/server";
+import { supaServer } from "@/lib/supabase-clients";
+
+export async function GET() {
+  const sb = supaServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+  const prof = user
+    ? await sb.from("profiles").select("*").eq("user_id", user.id).maybeSingle()
+    : null;
+  return NextResponse.json({
+    user: !!user,
+    profile: prof?.data ?? null,
+    err: prof?.error ?? null,
+  });
+}

--- a/apps/web/lib/supabase-clients.ts
+++ b/apps/web/lib/supabase-clients.ts
@@ -1,11 +1,34 @@
-import {
-  type SupabaseBrowserClient,
-  resetSupaBrowserClient,
-  supaBrowser,
-} from "@/lib/supabase-browser";
+import { createServerClient } from "@supabase/ssr";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-export function getSupabaseBrowserClient(): SupabaseBrowserClient {
-  return supaBrowser();
+export function supaServer(): SupabaseClient {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires -- lazy import for client compatibility
+  const { cookies, headers } = require("next/headers") as typeof import("next/headers");
+  const cookieStore = cookies() as any;
+  const hdrs = headers() as any;
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get: (k: string) => cookieStore.get(k)?.value,
+        set: (k: string, v: string, opts?: Record<string, unknown>) =>
+          cookieStore.set({ name: k, value: v, ...(opts ?? {}) }),
+        remove: (k: string, opts?: Record<string, unknown>) =>
+          cookieStore.set({ name: k, value: "", ...(opts ?? {}) }),
+      },
+      headers: { "x-forwarded-for": hdrs.get("x-forwarded-for") ?? "" },
+    } as unknown as Parameters<typeof createServerClient>[2]
+  ) as unknown as SupabaseClient;
 }
 
-export { resetSupaBrowserClient };
+let browserClient: SupabaseClient | null = null;
+export function supaBrowser(): SupabaseClient {
+  if (browserClient) return browserClient;
+  browserClient = createClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    { auth: { persistSession: true, storageKey: "umkmkits.supabase.auth" } }
+  );
+  return browserClient;
+}


### PR DESCRIPTION
## Summary
- switch the shared Supabase helper to `@supabase/ssr`, wiring cookies/headers for SSR and a cached browser client
- update the dashboard server/client pair to upsert profiles, load real data including onboarding fields, and show the onboarding modal until completion
- add the onboarding save API and an optional Supabase diagnostics endpoint for quick troubleshooting

## Testing
- CI=1 pnpm -C apps/web build

------
https://chatgpt.com/codex/tasks/task_e_68de5aa880b483278ba249331422f9e9