### PR TITLE
refactor: centralize font configuration

### DIFF
--- a/apps/web/app/[locale]/layout.tsx
+++ b/apps/web/app/[locale]/layout.tsx
@@ -3,14 +3,12 @@ import { NextIntlClientProvider } from "next-intl";
 import { notFound } from "next/navigation";
 import { ReactNode } from "react";
 import { unstable_setRequestLocale } from "next-intl/server";
-import { Plus_Jakarta_Sans } from "next/font/google";
 
 import { cn } from "@/lib/utils";
 import { ToasterClient } from "@/components/ToasterClient";
 import { isValidLocale, locales } from "@/lib/i18n";
 import { FooterNoSSR, NavbarNoSSR } from "@/components/no-ssr";
-
-const jakarta = Plus_Jakarta_Sans({ subsets: ["latin"], variable: "--font-sans", display: "swap" });
+import { fontSans } from "@/styles/fonts";
 
 export const dynamic = "force-dynamic";
 export const dynamicParams = true;
@@ -46,7 +44,7 @@ export default async function LocaleLayout({
       <body
         className={cn(
           "min-h-dvh bg-background text-foreground font-sans antialiased",
-          jakarta.variable
+          fontSans.variable
         )}
       >
         <NextIntlClientProvider locale={locale} messages={messages}>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -1,16 +1,10 @@
 import type { Metadata } from "next";
-import { Plus_Jakarta_Sans } from "next/font/google";
 import type { ReactNode } from "react";
 
 import { cn } from "@/lib/utils";
 import "@/styles/globals.css";
 import "sonner/dist/styles.css";
-
-const fontSans = Plus_Jakarta_Sans({
-  subsets: ["latin"],
-  variable: "--font-sans",
-  display: "swap",
-});
+import { fontSans } from "@/styles/fonts";
 
 export const metadata: Metadata = {
   title: "UMKM Kits Studio",

--- a/apps/web/src/styles/fonts.ts
+++ b/apps/web/src/styles/fonts.ts
@@ -1,0 +1,7 @@
+import { Plus_Jakarta_Sans } from "next/font/google";
+
+export const fontSans = Plus_Jakarta_Sans({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap",
+});


### PR DESCRIPTION
## Summary
- add a shared `fontSans` export for the Plus Jakarta Sans configuration
- update the root and locale layouts to consume the shared font instance

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de8e1673488327bb26d0f454f2c835