### PR TITLE
Add caption AI studio with n8n workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,15 @@ Monorepo untuk platform kreatif UMKM Kits Studio. Struktur ini terdiri atas apli
    cp apps/web/.env.example apps/web/.env.local
    ```
 
-   Buka `apps/web/.env.local` kemudian isi seluruh variabel dengan kredensial Supabase, SMTP, dan URL aplikasi Anda sebelum menjalankan secara lokal maupun produksi.
+   Buka `apps/web/.env.local` kemudian isi seluruh variabel dengan kredensial Supabase, SMTP, dan URL aplikasi Anda sebelum menjalankan secara lokal maupun produksi. Tambahkan pula konfigurasi integrasi n8n berikut untuk mengaktifkan halaman Caption AI:
+
+   ```bash
+   N8N_CAPTION_WEBHOOK_URL="https://workflow.example.com/webhook/ai-caption"
+   N8N_CAPTION_WEBHOOK_TOKEN="token-opsional-jika-diperlukan"
+   N8N_CALLBACK_SECRET="secret-yang-sama-di-n8n"
+   ```
+
+   Jika variabel di atas tidak diisi, generator akan menggunakan data mock sehingga pengujian UI tetap dapat dilakukan.
 
 3. **Buat tabel OTP di Supabase**
 
@@ -69,6 +77,7 @@ Monorepo untuk platform kreatif UMKM Kits Studio. Struktur ini terdiri atas apli
 - Guard environment disediakan lewat pengecekan variabel sebelum inisialisasi klien Supabase.
 - Rate limiting berbasis token bucket in-memory tersedia dengan opsi Redis.
 - Workflow n8n mencakup contoh job caption dan callback aman.
+- Halaman `/[locale]/caption-ai` menyediakan form generator caption profesional lengkap dengan preset strategi dan riwayat job yang terhubung ke n8n.
 
 ## Lisensi
 

--- a/apps/web/app/[locale]/caption-ai/CaptionGeneratorClient.tsx
+++ b/apps/web/app/[locale]/caption-ai/CaptionGeneratorClient.tsx
@@ -49,6 +49,7 @@ type CaptionResult = {
     promptUsed?: string;
   } | null;
   meta?: Record<string, any> | null;
+  resultUrl?: string | null;
 };
 
 type CaptionGeneratorClientProps = {

--- a/apps/web/app/[locale]/caption-ai/CaptionGeneratorClient.tsx
+++ b/apps/web/app/[locale]/caption-ai/CaptionGeneratorClient.tsx
@@ -1,0 +1,650 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import type { Locale as DateLocale } from "date-fns";
+import { formatDistanceToNow } from "date-fns";
+import { enUS, id as idLocale } from "date-fns/locale";
+import {
+  ArrowRight,
+  Check,
+  ClipboardCopy,
+  ClipboardList,
+  Loader2,
+  Sparkles,
+  Wand2,
+} from "lucide-react";
+import { useTranslations } from "next-intl";
+
+import { Button } from "@/components/ui/button";
+import { CardX, CardXFooter, CardXHeader } from "@/components/ui/cardx";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Slider } from "@/components/ui/slider";
+import { cn } from "@/lib/utils";
+
+type CaptionHistoryItem = {
+  id: string;
+  status: string;
+  created_at: string;
+  result_url?: string | null;
+  meta?: Record<string, any> | null;
+};
+
+type CaptionResult = {
+  jobId: string;
+  status: string;
+  primary?: string | null;
+  variations: Array<{ id: string; caption: string; tone?: string }>;
+  hashtags?: string[];
+  insights?: {
+    hook?: string;
+    story?: string;
+    closing?: string;
+    promptUsed?: string;
+  } | null;
+  meta?: Record<string, any> | null;
+};
+
+type CaptionGeneratorClientProps = {
+  locale: string;
+  initialHistory: CaptionHistoryItem[];
+};
+
+type FormState = {
+  brief: string;
+  platform: string;
+  tone: string;
+  audience: string;
+  language: string;
+  length: "short" | "medium" | "long";
+  includeHashtags: boolean;
+  includeCTA: boolean;
+  includeEmoji: boolean;
+  customHashtags: string;
+  customCTA: string;
+  brandVoice: string;
+  differentiator: string;
+  keywords: string;
+  competitorAngles: string;
+  variations: number;
+};
+
+const textareaBaseClass =
+  "min-h-[120px] w-full rounded-2xl border border-border bg-background/70 px-4 py-3 text-sm text-foreground transition focus:outline-none focus:ring-2 focus:ring-primary/50";
+
+const languageLocales: Record<string, DateLocale> = {
+  id: idLocale,
+  en: enUS,
+};
+
+const PLATFORM_OPTIONS = [
+  { value: "instagram", label: "Instagram" },
+  { value: "tiktok", label: "TikTok" },
+  { value: "facebook", label: "Facebook" },
+  { value: "whatsapp", label: "WhatsApp" },
+  { value: "twitter", label: "Twitter / X" },
+  { value: "linkedin", label: "LinkedIn" },
+  { value: "general", label: "Omni-channel" },
+];
+
+const TONE_OPTIONS = [
+  { value: "professional", label: "Professional" },
+  { value: "friendly", label: "Friendly" },
+  { value: "playful", label: "Playful" },
+  { value: "luxurious", label: "Luxurious" },
+  { value: "bold", label: "Bold" },
+];
+
+const LENGTH_OPTIONS: Array<{ value: FormState["length"]; label: string; range: string }> = [
+  { value: "short", label: "Short", range: "60-80" },
+  { value: "medium", label: "Medium", range: "120-160" },
+  { value: "long", label: "Long", range: "220-280" },
+];
+
+const LANGUAGE_OPTIONS = [
+  { value: "id", label: "Bahasa Indonesia" },
+  { value: "en", label: "English" },
+];
+
+const BRIEF_PRESETS = [
+  {
+    id: "coffee",
+    title: "Signature coffee soft launch",
+    value:
+      "Launching menu seasonal Es Kopi Aren premium dengan gula aren artisan, highlight pada rasa smoky dan tekstur creamy. Target pekerja kantoran usia 23-35 dengan promo bundling pagi hari.",
+    tone: "professional",
+    platform: "instagram",
+  },
+  {
+    id: "bakery",
+    title: "Artisan sourdough drop",
+    value:
+      "Buka pre-order sourdough loaf terbatas dengan topping garlic butter dan keju lokal. Tekankan bahan alami dan fermentasi 48 jam, cocok untuk sarapan keluarga muda.",
+    tone: "friendly",
+    platform: "whatsapp",
+  },
+  {
+    id: "beverage",
+    title: "Fresh juice campaign",
+    value:
+      "Promo paket detox jus cold-pressed 3 hari dengan konsultasi gizi gratis. Fokus pada manfaat kesehatan, ingredients lokal, dan testimoni pelanggan.",
+    tone: "luxurious",
+    platform: "tiktok",
+  },
+];
+
+export default function CaptionGeneratorClient({
+  locale,
+  initialHistory,
+}: CaptionGeneratorClientProps) {
+  const t = useTranslations("captionAi");
+  const [form, setForm] = useState<FormState>({
+    brief: BRIEF_PRESETS[0]?.value ?? "",
+    platform: BRIEF_PRESETS[0]?.platform ?? "instagram",
+    tone: BRIEF_PRESETS[0]?.tone ?? "professional",
+    audience: "Pekerja kantoran urban, suka trend kopi modern",
+    language: locale === "en" ? "en" : "id",
+    length: "medium",
+    includeHashtags: true,
+    includeCTA: true,
+    includeEmoji: true,
+    customHashtags: "#umkmindonesia, #minumanhits, #supportlocal",
+    customCTA: "Pesan sekarang melalui link di bio",
+    brandVoice: "Optimis, percaya diri, mengedepankan kualitas lokal dengan sentuhan modern.",
+    differentiator: "Menggunakan gula aren organik dari petani lokal dengan proses manual harian.",
+    keywords: "kopi gula aren, creamy, smoky, promo bundling",
+    competitorAngles: "kopi franchise premium, coffee shop artisan",
+    variations: 3,
+  });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<CaptionResult | null>(null);
+  const [history, setHistory] = useState<CaptionHistoryItem[]>(initialHistory);
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  const activeLocale = languageLocales[form.language] ?? idLocale;
+
+  const handleChange = <K extends keyof FormState>(key: K, value: FormState[K]) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!form.brief.trim()) {
+      setError(t("errors.emptyBrief"));
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      const response = await fetch("/api/ai/caption", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          ...form,
+        }),
+      });
+      const data = (await response.json()) as CaptionResult & { error?: string };
+      if (!response.ok) {
+        throw new Error(data?.error ?? "Failed to generate caption");
+      }
+      setResult(data);
+      setHistory((prev) => [
+        {
+          id: data.jobId,
+          status: data.status,
+          created_at: new Date().toISOString(),
+          result_url: data.resultUrl ?? null,
+          meta: data.meta ?? null,
+        },
+        ...prev,
+      ]);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      setError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleCopy = async (value: string, id: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopiedId(id);
+      setTimeout(() => setCopiedId(null), 1500);
+    } catch (err) {
+      console.warn("[caption-ai] Clipboard copy failed", err);
+    }
+  };
+
+  const handlePreset = (presetId: string) => {
+    const preset = BRIEF_PRESETS.find((item) => item.id === presetId);
+    if (!preset) return;
+    setForm((prev) => ({
+      ...prev,
+      brief: preset.value,
+      tone: preset.tone,
+      platform: preset.platform,
+    }));
+  };
+
+  const generatedVariations = useMemo(() => {
+    if (!result) return [] as Array<{ id: string; caption: string; tone?: string }>;
+    if (Array.isArray(result.variations) && result.variations.length > 0) {
+      return result.variations;
+    }
+    if (result.primary) {
+      return [
+        {
+          id: `${result.jobId}-primary`,
+          caption: result.primary,
+          tone: result.meta?.tone ?? form.tone,
+        },
+      ];
+    }
+    return [];
+  }, [result, form.tone]);
+
+  return (
+    <div className="space-y-8">
+      <CardX tone="glass" padding="lg" className="border-primary/20">
+        <div className="flex flex-col gap-6 lg:flex-row lg:items-center lg:justify-between">
+          <div className="space-y-3">
+            <h1 className="text-3xl font-semibold text-foreground lg:text-4xl">
+              {t("title")}
+            </h1>
+            <p className="max-w-3xl text-sm text-muted-foreground lg:text-base">
+              {t("subtitle")}
+            </p>
+          </div>
+          <div className="grid gap-3 text-sm text-muted-foreground">
+            <div className="flex items-center gap-2">
+              <Sparkles className="h-4 w-4 text-primary" />
+              <span>{t("capabilities.pipelines")}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <ClipboardList className="h-4 w-4 text-primary" />
+              <span>{t("capabilities.templates")}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <Wand2 className="h-4 w-4 text-primary" />
+              <span>{t("capabilities.custom")}</span>
+            </div>
+          </div>
+        </div>
+      </CardX>
+
+      <div className="grid gap-6 xl:grid-cols-[minmax(0,0.62fr)_minmax(0,0.38fr)]">
+        <div className="space-y-6">
+          <CardX tone="surface" padding="lg" className="space-y-6">
+            <CardXHeader title={t("form.title")} subtitle={t("form.subtitle")} />
+            {error ? (
+              <div className="rounded-xl border border-red-500/40 bg-red-500/10 px-4 py-3 text-sm text-red-100">
+                {t("errors.general", { message: error })}
+              </div>
+            ) : null}
+            <form className="space-y-6" onSubmit={handleSubmit}>
+              <div className="grid gap-6 md:grid-cols-2">
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.platform")}</span>
+                  <Select value={form.platform} onValueChange={(value) => handleChange("platform", value)}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Instagram" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {PLATFORM_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.tone")}</span>
+                  <Select value={form.tone} onValueChange={(value) => handleChange("tone", value)}>
+                    <SelectTrigger>
+                      <SelectValue placeholder="Professional" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {TONE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.language")}</span>
+                  <Select value={form.language} onValueChange={(value) => handleChange("language", value)}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {LANGUAGE_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </label>
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.length")}</span>
+                  <Select
+                    value={form.length}
+                    onValueChange={(value) =>
+                      handleChange("length", value as FormState["length"])
+                    }
+                  >
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {LENGTH_OPTIONS.map((option) => (
+                        <SelectItem key={option.value} value={option.value}>
+                          {option.label} · {t("form.characters", { range: option.range })}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-xs text-muted-foreground">
+                    {t("form.characters", {
+                      range: LENGTH_OPTIONS.find((option) => option.value === form.length)?.range ?? "120-160",
+                    })}
+                  </p>
+                </label>
+              </div>
+
+              <div className="space-y-2">
+                <span className="text-sm font-medium text-muted-foreground">{t("form.variationLabel")}</span>
+                <div className="rounded-2xl border border-border bg-background/40 px-4 py-3">
+                  <Slider
+                    value={[form.variations]}
+                    min={1}
+                    max={5}
+                    step={1}
+                    onValueChange={([value]) => handleChange("variations", value)}
+                  />
+                  <div className="mt-3 flex items-center justify-between text-xs text-muted-foreground">
+                    <span>{t("form.variations", { count: form.variations })}</span>
+                    <span>{t("form.variationHint")}</span>
+                  </div>
+                </div>
+              </div>
+
+              <label className="space-y-2">
+                <span className="text-sm font-medium text-muted-foreground">{t("form.brief")}</span>
+                <textarea
+                  className={textareaBaseClass}
+                  value={form.brief}
+                  onChange={(event) => handleChange("brief", event.target.value)}
+                  placeholder={t("placeholders.brief")}
+                />
+              </label>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.audience")}</span>
+                  <Input
+                    value={form.audience}
+                    onChange={(event) => handleChange("audience", event.target.value)}
+                    placeholder={t("placeholders.audience")}
+                  />
+                </label>
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.brandVoice")}</span>
+                  <Input
+                    value={form.brandVoice}
+                    onChange={(event) => handleChange("brandVoice", event.target.value)}
+                    placeholder={t("placeholders.brandVoice")}
+                  />
+                </label>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.keywords")}</span>
+                  <textarea
+                    className={cn(textareaBaseClass, "min-h-[100px]")}
+                    value={form.keywords}
+                    onChange={(event) => handleChange("keywords", event.target.value)}
+                    placeholder={t("placeholders.keywords")}
+                  />
+                </label>
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.competitorAngles")}</span>
+                  <textarea
+                    className={cn(textareaBaseClass, "min-h-[100px]")}
+                    value={form.competitorAngles}
+                    onChange={(event) => handleChange("competitorAngles", event.target.value)}
+                    placeholder={t("placeholders.competitorAngles")}
+                  />
+                </label>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-3">
+                <label className="flex items-start gap-3 rounded-2xl border border-border bg-background/40 px-4 py-3">
+                  <input
+                    type="checkbox"
+                    className="mt-1 h-4 w-4 rounded border-border bg-background/80"
+                    checked={form.includeHashtags}
+                    onChange={(event) => handleChange("includeHashtags", event.target.checked)}
+                  />
+                  <div className="space-y-1 text-sm">
+                    <p className="font-medium text-foreground">{t("form.includeHashtags")}</p>
+                    <p className="text-xs text-muted-foreground">{t("form.includeHashtagsHint")}</p>
+                  </div>
+                </label>
+                <label className="flex items-start gap-3 rounded-2xl border border-border bg-background/40 px-4 py-3">
+                  <input
+                    type="checkbox"
+                    className="mt-1 h-4 w-4 rounded border-border bg-background/80"
+                    checked={form.includeCTA}
+                    onChange={(event) => handleChange("includeCTA", event.target.checked)}
+                  />
+                  <div className="space-y-1 text-sm">
+                    <p className="font-medium text-foreground">{t("form.includeCTA")}</p>
+                    <p className="text-xs text-muted-foreground">{t("form.includeCTAHint")}</p>
+                  </div>
+                </label>
+                <label className="flex items-start gap-3 rounded-2xl border border-border bg-background/40 px-4 py-3">
+                  <input
+                    type="checkbox"
+                    className="mt-1 h-4 w-4 rounded border-border bg-background/80"
+                    checked={form.includeEmoji}
+                    onChange={(event) => handleChange("includeEmoji", event.target.checked)}
+                  />
+                  <div className="space-y-1 text-sm">
+                    <p className="font-medium text-foreground">{t("form.includeEmoji")}</p>
+                    <p className="text-xs text-muted-foreground">{t("form.includeEmojiHint")}</p>
+                  </div>
+                </label>
+              </div>
+
+              <div className="grid gap-6 md:grid-cols-2">
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.customHashtags")}</span>
+                  <textarea
+                    className={cn(textareaBaseClass, "min-h-[80px]")}
+                    value={form.customHashtags}
+                    onChange={(event) => handleChange("customHashtags", event.target.value)}
+                    placeholder={t("placeholders.hashtags")}
+                    disabled={!form.includeHashtags}
+                  />
+                </label>
+                <label className="space-y-2">
+                  <span className="text-sm font-medium text-muted-foreground">{t("form.customCTA")}</span>
+                  <textarea
+                    className={cn(textareaBaseClass, "min-h-[80px]")}
+                    value={form.customCTA}
+                    onChange={(event) => handleChange("customCTA", event.target.value)}
+                    placeholder={t("placeholders.cta")}
+                    disabled={!form.includeCTA}
+                  />
+                </label>
+              </div>
+
+              <CardXFooter>
+                <Button type="submit" size="lg" disabled={isSubmitting}>
+                  {isSubmitting ? (
+                    <>
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      {t("actions.generating")}
+                    </>
+                  ) : (
+                    <>
+                      <Sparkles className="mr-2 h-4 w-4" />
+                      {t("actions.generate")}
+                    </>
+                  )}
+                </Button>
+                <Button
+                  type="button"
+                  variant="secondary"
+                  onClick={() => handleChange("brief", "")}
+                  disabled={isSubmitting}
+                >
+                  {t("actions.clear")}
+                </Button>
+              </CardXFooter>
+            </form>
+          </CardX>
+
+          <CardX tone="surface" padding="lg" className="space-y-6">
+            <CardXHeader title={t("output.title")} subtitle={t("output.subtitle")} />
+            {result ? (
+              <div className="space-y-6">
+                {generatedVariations.map((variation) => (
+                  <div key={variation.id} className="rounded-2xl border border-border/60 bg-background/40 p-4">
+                    <div className="flex items-start justify-between gap-4">
+                      <div className="space-y-3">
+                        <div className="flex items-center gap-2 text-xs font-medium uppercase tracking-[0.2em] text-primary">
+                          <Sparkles className="h-4 w-4" />
+                          {t("output.variant")}
+                        </div>
+                        <p className="whitespace-pre-line text-sm text-foreground">{variation.caption}</p>
+                        {Array.isArray(result.hashtags) && result.hashtags.length > 0 ? (
+                          <p className="text-xs text-primary/80">{result.hashtags.join(" ")}</p>
+                        ) : null}
+                      </div>
+                      <Button
+                        size="icon"
+                        variant="ghost"
+                        className="h-9 w-9"
+                        onClick={() => handleCopy(variation.caption, variation.id)}
+                      >
+                        {copiedId === variation.id ? (
+                          <Check className="h-4 w-4 text-primary" />
+                        ) : (
+                          <ClipboardCopy className="h-4 w-4" />
+                        )}
+                        <span className="sr-only">{t("output.copy")}</span>
+                      </Button>
+                    </div>
+                  </div>
+                ))}
+                {result?.insights ? (
+                  <div className="rounded-2xl border border-border/60 bg-background/40 p-5">
+                    <h3 className="text-sm font-semibold text-foreground">
+                      {t("output.insightsTitle")}
+                    </h3>
+                    <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
+                      {result.insights.hook ? <li>• {result.insights.hook}</li> : null}
+                      {result.insights.story ? <li>• {result.insights.story}</li> : null}
+                      {result.insights.closing ? <li>• {result.insights.closing}</li> : null}
+                    </ul>
+                    {result.insights.promptUsed ? (
+                      <p className="mt-3 text-xs text-muted-foreground/80">
+                        {t("output.prompt")}: {result.insights.promptUsed}
+                      </p>
+                    ) : null}
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="rounded-2xl border border-dashed border-border/60 bg-background/20 p-6 text-center text-sm text-muted-foreground">
+                {t("output.emptyState")}
+              </div>
+            )}
+          </CardX>
+        </div>
+
+        <div className="space-y-6">
+          <CardX tone="surface" padding="lg" className="space-y-6">
+            <CardXHeader title={t("presets.title")} subtitle={t("presets.subtitle")} />
+            <div className="grid gap-3">
+              {BRIEF_PRESETS.map((preset) => (
+                <button
+                  key={preset.id}
+                  type="button"
+                  onClick={() => handlePreset(preset.id)}
+                  className="group rounded-2xl border border-border bg-background/30 px-4 py-4 text-left transition hover:border-primary/60 hover:bg-primary/5"
+                >
+                  <p className="text-sm font-semibold text-foreground group-hover:text-primary">
+                    {preset.title}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">{preset.value}</p>
+                </button>
+              ))}
+            </div>
+          </CardX>
+
+          <CardX tone="surface" padding="lg" className="space-y-6">
+            <CardXHeader title={t("history.title")} subtitle={t("history.subtitle")} />
+            {history.length > 0 ? (
+              <ul className="space-y-4 text-sm">
+                {history.slice(0, 6).map((item) => (
+                  <li key={item.id} className="rounded-2xl border border-border/60 bg-background/30 p-4">
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <p className="font-semibold text-foreground">#{item.id.slice(0, 8)}</p>
+                        <p className="text-xs uppercase tracking-[0.3em] text-primary">
+                          {item.status.toUpperCase()}
+                        </p>
+                      </div>
+                      <span className="text-xs text-muted-foreground">
+                        {formatDistanceToNow(new Date(item.created_at), {
+                          addSuffix: true,
+                          locale: activeLocale,
+                        })}
+                      </span>
+                    </div>
+                    {item.meta?.platform || item.meta?.tone ? (
+                      <p className="mt-3 text-xs text-muted-foreground">
+                        {item.meta?.platform ? `${item.meta.platform}` : ""}
+                        {item.meta?.tone ? ` • ${item.meta.tone}` : ""}
+                      </p>
+                    ) : null}
+                    {item.result_url ? (
+                      <a
+                        className="mt-3 inline-flex items-center gap-2 text-xs font-medium text-primary hover:text-primary/80"
+                        href={item.result_url}
+                        target="_blank"
+                        rel="noreferrer"
+                      >
+                        {t("history.viewWorkflow")}
+                        <ArrowRight className="h-3 w-3" />
+                      </a>
+                    ) : null}
+                  </li>
+                ))}
+              </ul>
+            ) : (
+              <p className="text-sm text-muted-foreground">{t("history.empty")}</p>
+            )}
+          </CardX>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/[locale]/caption-ai/page.tsx
+++ b/apps/web/app/[locale]/caption-ai/page.tsx
@@ -1,0 +1,45 @@
+import { redirect } from "next/navigation";
+
+import { supaServer } from "@/lib/supabase-server-ssr";
+
+import CaptionGeneratorClient from "./CaptionGeneratorClient";
+
+export const dynamic = "force-dynamic";
+
+export default async function CaptionAiPage({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}) {
+  const { locale } = await params;
+  const sb = await supaServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+
+  if (!user) {
+    const search = new URLSearchParams({ redirect: `/${locale}/caption-ai` });
+    redirect(`/${locale}/sign-in?${search.toString()}`);
+  }
+
+  const { data: jobs } = await sb
+    .from("ai_jobs")
+    .select("id, status, created_at, result_url, meta")
+    .eq("user_id", user.id)
+    .eq("job_type", "caption")
+    .order("created_at", { ascending: false })
+    .limit(12);
+
+  return (
+    <CaptionGeneratorClient
+      locale={locale}
+      initialHistory={(jobs ?? []).map((job) => ({
+        id: job.id,
+        status: job.status,
+        created_at: job.created_at,
+        result_url: job.result_url ?? null,
+        meta: job.meta ?? null,
+      }))}
+    />
+  );
+}

--- a/apps/web/app/api/ai/caption/callback/route.ts
+++ b/apps/web/app/api/ai/caption/callback/route.ts
@@ -33,7 +33,7 @@ export async function POST(req: Request) {
 
   const admin = supaAdmin();
 
-  await admin
+  const { error: updateError } = await admin
     .from("ai_jobs")
     .update({
       status: parsed.data.status,
@@ -47,10 +47,12 @@ export async function POST(req: Request) {
         primary: parsed.data.primary ?? null,
       },
     })
-    .eq("id", parsed.data.jobId)
-    .catch((error: unknown) => {
-      console.error("[caption-ai] Failed to update job from callback", error);
-    });
+    .eq("id", parsed.data.jobId);
+
+  if (updateError) {
+    console.error("[caption-ai] Failed to update job from callback", updateError);
+    return NextResponse.json({ error: "UPDATE_FAILED" }, { status: 500 });
+  }
 
   return NextResponse.json({ ok: true });
 }

--- a/apps/web/app/api/ai/caption/callback/route.ts
+++ b/apps/web/app/api/ai/caption/callback/route.ts
@@ -1,0 +1,56 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { supaAdmin } from "@/lib/supabase-server";
+
+const CallbackSchema = z.object({
+  jobId: z.string().uuid(),
+  status: z.enum(["queued", "processing", "succeeded", "failed", "cancelled"]).default("succeeded"),
+  resultUrl: z.string().url().optional(),
+  meta: z.record(z.any()).optional(),
+  insights: z.any().optional(),
+  variations: z.array(z.any()).optional(),
+  hashtags: z.array(z.string()).optional(),
+  primary: z.string().optional(),
+});
+
+export async function POST(req: Request) {
+  const token = req.headers.get("x-callback-token");
+  const secret = process.env.N8N_CALLBACK_SECRET;
+
+  if (!secret || !token || token !== secret) {
+    return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => ({}));
+  const parsed = CallbackSchema.safeParse(json);
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: "INVALID_PAYLOAD", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const admin = supaAdmin();
+
+  await admin
+    .from("ai_jobs")
+    .update({
+      status: parsed.data.status,
+      result_url: parsed.data.resultUrl ?? null,
+      meta: {
+        ...(parsed.data.meta ?? {}),
+        receivedAt: new Date().toISOString(),
+        insights: parsed.data.insights ?? null,
+        variations: parsed.data.variations ?? null,
+        hashtags: parsed.data.hashtags ?? null,
+        primary: parsed.data.primary ?? null,
+      },
+    })
+    .eq("id", parsed.data.jobId)
+    .catch((error: unknown) => {
+      console.error("[caption-ai] Failed to update job from callback", error);
+    });
+
+  return NextResponse.json({ ok: true });
+}

--- a/apps/web/app/api/ai/caption/route.ts
+++ b/apps/web/app/api/ai/caption/route.ts
@@ -168,7 +168,7 @@ export async function POST(req: Request) {
 
   const status = (effectiveResponse.status as string | undefined) ?? (n8nError ? "failed" : "succeeded");
 
-  await sb
+  const { error: insertError } = await sb
     .from("ai_jobs")
     .insert({
       id: jobId,
@@ -181,10 +181,11 @@ export async function POST(req: Request) {
         webhookError: n8nError,
       },
       result_url: effectiveResponse.resultUrl ?? null,
-    })
-    .catch((error: unknown) => {
-      console.warn("[caption-ai] Failed to record ai_jobs", error);
     });
+
+  if (insertError) {
+    console.warn("[caption-ai] Failed to record ai_jobs", insertError);
+  }
 
   return NextResponse.json({
     jobId,

--- a/apps/web/app/api/ai/caption/route.ts
+++ b/apps/web/app/api/ai/caption/route.ts
@@ -1,0 +1,204 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { z } from "zod";
+
+import { getBaseUrl } from "@/lib/base-url";
+import { supaServer } from "@/lib/supabase-server-ssr";
+
+const CaptionRequestSchema = z.object({
+  brief: z.string().min(10).max(800),
+  platform: z
+    .enum(["instagram", "tiktok", "facebook", "whatsapp", "twitter", "linkedin", "general"])
+    .default("instagram"),
+  tone: z.enum(["friendly", "professional", "playful", "luxurious", "bold"]).default("professional"),
+  audience: z.string().max(240).optional(),
+  language: z.string().min(2).max(10).default("id"),
+  length: z.enum(["short", "medium", "long"]).default("medium"),
+  includeHashtags: z.boolean().default(true),
+  includeCTA: z.boolean().default(true),
+  includeEmoji: z.boolean().default(true),
+  customHashtags: z.string().max(240).optional(),
+  customCTA: z.string().max(240).optional(),
+  brandVoice: z.string().max(400).optional(),
+  differentiator: z.string().max(280).optional(),
+  keywords: z.array(z.string().max(40)).max(8).optional(),
+  competitorAngles: z.array(z.string().max(80)).max(6).optional(),
+  variations: z.number().int().min(1).max(5).default(3),
+});
+
+const FALLBACK_VARIATIONS = [
+  {
+    id: "v1",
+    caption:
+      "✨ Temukan sensasi baru dari kopi gula aren kami yang dibuat fresh setiap jam! Nikmati kombinasi creamy dan karamel yang pas untuk menemani aktivitasmu. Pesan sekarang dan rasakan bedanya!",
+    tone: "professional",
+  },
+  {
+    id: "v2",
+    caption:
+      "Butuh booster semangat? Coba es kopi gula aren favorit pelanggan kami. Dibuat dari biji pilihan dan susu segar, siap mengupgrade harimu hanya dalam satu teguk.",
+    tone: "friendly",
+  },
+  {
+    id: "v3",
+    caption:
+      "Mulai pagi dengan signature coffee kami: gula aren smoky, espresso bold, dan susu silky yang bikin nagih. Grab yours today & tag bestie kamu! ☕",
+    tone: "playful",
+  },
+];
+
+function buildMockResponse(body: z.infer<typeof CaptionRequestSchema>) {
+  const first = FALLBACK_VARIATIONS[0]?.caption ?? "";
+  return {
+    jobId: crypto.randomUUID(),
+    status: "succeeded" as const,
+    primary: first,
+    variations: FALLBACK_VARIATIONS,
+    hashtags: body.includeHashtags
+      ? body.customHashtags?.split(/[,\n]+/).map((tag) => tag.trim()).filter(Boolean) ?? [
+          "#kopilokal",
+          "#umkmkreatif",
+          "#coffeeholic",
+        ]
+      : [],
+    meta: {
+      platform: body.platform,
+      tone: body.tone,
+      language: body.language,
+      length: body.length,
+      audience: body.audience ?? null,
+      includeCTA: body.includeCTA,
+      includeEmoji: body.includeEmoji,
+      includeHashtags: body.includeHashtags,
+      requestedAt: new Date().toISOString(),
+      mock: true,
+    },
+    insights: {
+      hook:
+        "Gunakan pertanyaan retoris dan highlight keunikan gula aren lokal untuk menarik perhatian audiens di 3 detik pertama.",
+      story:
+        "Soroti proses pembuatan handmade dan gunakan kata kerja aktif untuk menggambarkan sensasi rasa secara visual.",
+      closing:
+        body.includeCTA
+          ? body.customCTA ?? "Arahkan audiens ke link pemesanan dengan CTA spesifik seperti ‘Pesan sekarang’ atau ‘Pre-order hari ini’."
+          : "Tambahkan CTA ketika siap mengarahkan audiens ke aksi tertentu.",
+      promptUsed:
+        "You are an expert Indonesian social media strategist for F&B brands. Generate captions that follow the UMKM Kits Studio playbook.",
+    },
+  };
+}
+
+function normaliseStringArray(value?: string | string[] | null) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value.filter(Boolean);
+  return value
+    .split(/[,\n]+/)
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+export async function POST(req: Request) {
+  const sb = await supaServer();
+  const {
+    data: { user },
+  } = await sb.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  const json = await req.json().catch(() => ({}));
+  const parsed = CaptionRequestSchema.safeParse({
+    ...json,
+    keywords: normaliseStringArray(json?.keywords),
+    competitorAngles: normaliseStringArray(json?.competitorAngles),
+  });
+
+  if (!parsed.success) {
+    return NextResponse.json({ error: "INVALID_REQUEST", details: parsed.error.flatten() }, { status: 400 });
+  }
+
+  const payload = parsed.data;
+  const jobId = crypto.randomUUID();
+  const baseUrl = await getBaseUrl();
+
+  const webhookUrl = process.env.N8N_CAPTION_WEBHOOK_URL;
+  const webhookToken = process.env.N8N_CAPTION_WEBHOOK_TOKEN;
+
+  let n8nResponse: any = null;
+  let n8nStatus: number | null = null;
+  let n8nError: string | null = null;
+
+  if (webhookUrl) {
+    try {
+      const response = await fetch(webhookUrl, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          ...(webhookToken ? { Authorization: `Bearer ${webhookToken}` } : {}),
+        },
+        body: JSON.stringify({
+          jobId,
+          userId: user.id,
+          callbackUrl: `${baseUrl}/api/ai/caption/callback`,
+          options: payload,
+        }),
+      });
+      n8nStatus = response.status;
+      const text = await response.text();
+      try {
+        n8nResponse = text ? JSON.parse(text) : {};
+      } catch (error) {
+        n8nResponse = { raw: text };
+      }
+      if (!response.ok) {
+        n8nError = `N8N_WEBHOOK_ERROR_${response.status}`;
+      }
+    } catch (error) {
+      console.error("[caption-ai] Failed to reach n8n webhook", error);
+      n8nError = "N8N_WEBHOOK_UNREACHABLE";
+    }
+  }
+
+  const effectiveResponse =
+    n8nResponse && typeof n8nResponse === "object" && Object.keys(n8nResponse).length > 0
+      ? n8nResponse
+      : buildMockResponse(payload);
+
+  const status = (effectiveResponse.status as string | undefined) ?? (n8nError ? "failed" : "succeeded");
+
+  await sb
+    .from("ai_jobs")
+    .insert({
+      id: jobId,
+      user_id: user.id,
+      job_type: "caption",
+      status,
+      meta: {
+        ...payload,
+        webhookStatus: n8nStatus,
+        webhookError: n8nError,
+      },
+      result_url: effectiveResponse.resultUrl ?? null,
+    })
+    .catch((error: unknown) => {
+      console.warn("[caption-ai] Failed to record ai_jobs", error);
+    });
+
+  return NextResponse.json({
+    jobId,
+    status,
+    primary: effectiveResponse.primary ?? effectiveResponse.caption ?? effectiveResponse.result ?? null,
+    variations: effectiveResponse.variations ?? [],
+    hashtags: effectiveResponse.hashtags ?? [],
+    insights: effectiveResponse.insights ?? null,
+    resultUrl: effectiveResponse.resultUrl ?? null,
+    meta: {
+      ...(effectiveResponse.meta ?? {}),
+      requestedAt: new Date().toISOString(),
+      jobId,
+      webhookError: n8nError,
+    },
+  });
+}

--- a/apps/web/lib/supabase-clients.ts
+++ b/apps/web/lib/supabase-clients.ts
@@ -1,14 +1,17 @@
 import { createServerClient, type CookieOptions } from "@supabase/ssr";
 import { createClient, type SupabaseClient } from "@supabase/supabase-js";
 
-const SUPABASE_URL = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const SUPABASE_ANON_KEY = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
 
-if (!SUPABASE_URL || !SUPABASE_ANON_KEY) {
+if (!supabaseUrl || !supabaseAnonKey) {
   throw new Error(
     "Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY environment variables"
   );
 }
+
+const SUPABASE_URL = supabaseUrl;
+const SUPABASE_ANON_KEY = supabaseAnonKey;
 
 export type SupabaseServerAccess = "readonly" | "readwrite";
 
@@ -71,16 +74,16 @@ export function supaServer(
   access: SupabaseServerAccess = "readonly"
 ): SupabaseServerClient {
   const { cookies: cookieStore, headers: headerStore } = resolveRequestStores();
-  const cookies = createCookieAdapter(cookieStore as CookieStore, access);
+  const cookies = createCookieAdapter(cookieStore as unknown as CookieStore, access);
 
   return createServerClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
     cookies,
     global: {
       headers: {
-        "x-forwarded-for": (headerStore as HeaderStore).get("x-forwarded-for") ?? "",
+        "x-forwarded-for": (headerStore as unknown as HeaderStore).get("x-forwarded-for") ?? "",
       },
     },
-  }) as SupabaseServerClient;
+  }) as unknown as SupabaseServerClient;
 }
 
 declare global {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -25,6 +25,7 @@
     "bcryptjs": "^2.4.3",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
+    "date-fns": "^3.6.0",
     "framer-motion": "^11.11.17",
     "nodemailer": "^6.9.15",
     "html-to-image": "^1.11.11",

--- a/apps/web/src/components/auth/AuthNav.tsx
+++ b/apps/web/src/components/auth/AuthNav.tsx
@@ -40,9 +40,11 @@ export default function AuthNav({
   const fallback = defaultLocale;
   const finalLocale: Locale = activeLocale ?? fallback;
   const dashboardHref = useMemo(() => href("/[locale]/dashboard", finalLocale), [finalLocale]);
+  const captionHref = useMemo(() => href("/[locale]/caption-ai", finalLocale), [finalLocale]);
   const signInHref = useMemo(() => href("/[locale]/sign-in", finalLocale), [finalLocale]);
   const signUpHref = useMemo(() => href("/[locale]/sign-up", finalLocale), [finalLocale]);
   const dashboardPathname = `/${finalLocale}/dashboard`;
+  const captionPathname = `/${finalLocale}/caption-ai`;
 
   useEffect(() => {
     let cancelled = false;
@@ -100,6 +102,15 @@ export default function AuthNav({
     <div className={cn(containerClasses, className)}>
       {isLoggedIn ? (
         <>
+          {pathname !== captionPathname && (
+            <Link
+              href={captionHref}
+              className={cn(actionBaseClass, "bg-card/30 border border-border hover:bg-card/50")}
+              onClick={handleNavigate}
+            >
+              Caption AI
+            </Link>
+          )}
           {pathname !== dashboardPathname && (
             <Link
               href={dashboardHref}

--- a/apps/web/src/components/lang-toggle.tsx
+++ b/apps/web/src/components/lang-toggle.tsx
@@ -35,6 +35,8 @@ function buildTargetHref(pathname: string | null | undefined, locale: Locale) {
         return href('/[locale]/dashboard', locale);
       case 'gallery':
         return href('/[locale]/gallery', locale);
+      case 'caption-ai':
+        return href('/[locale]/caption-ai', locale);
       case 'forgot-password':
         return href('/[locale]/forgot-password', locale);
       case 'sign-in':

--- a/apps/web/src/messages/en.json
+++ b/apps/web/src/messages/en.json
@@ -18,5 +18,76 @@
     "welcome": "Welcome back",
     "upload": "Upload your product photo",
     "recentJobs": "Recent AI jobs"
+  },
+  "captionAi": {
+    "title": "Professional caption studio",
+    "subtitle": "Craft omnichannel captions with precise tone, CTA and hashtag controls. Pipe every request through the secure n8n workflow.",
+    "capabilities": {
+      "pipelines": "Automated n8n pipelines with secure callback",
+      "templates": "Battle-tested F&B campaign presets",
+      "custom": "Deep customization for tone, CTA and hashtags"
+    },
+    "form": {
+      "title": "Design your caption strategy",
+      "subtitle": "Describe the campaign so the generator can tailor copy to your brand audience.",
+      "platform": "Platform",
+      "tone": "Tone of voice",
+      "language": "Content language",
+      "length": "Caption length",
+      "variationLabel": "Number of variations",
+      "variations": "{count} variations",
+      "variationHint": "Up to 5 variations per request",
+      "characters": "{range} characters",
+      "brief": "Creative brief",
+      "audience": "Primary audience",
+      "brandVoice": "Brand voice",
+      "keywords": "Key keywords",
+      "competitorAngles": "Competitor angles",
+      "includeHashtags": "Include hashtags",
+      "includeHashtagsHint": "Generator will craft or merge your custom hashtags",
+      "includeCTA": "Enable CTA",
+      "includeCTAHint": "Add a specific action for the audience",
+      "includeEmoji": "Dynamic emojis",
+      "includeEmojiHint": "Align caption mood with emojis",
+      "customHashtags": "Custom hashtags",
+      "customCTA": "Custom CTA"
+    },
+    "placeholders": {
+      "brief": "Example: soft launch a seasonal drink with morning bundle promo",
+      "audience": "E.g. young urban professionals active on Instagram",
+      "brandVoice": "E.g. optimistic, warm, celebrates local ingredients",
+      "keywords": "Separate by commas or new lines",
+      "competitorAngles": "List how you differentiate from competitors",
+      "hashtags": "Add specific hashtags if needed",
+      "cta": "E.g. Order via WhatsApp or tap link in bio"
+    },
+    "actions": {
+      "generate": "Generate caption",
+      "generating": "Connecting to n8n...",
+      "clear": "Clear brief"
+    },
+    "output": {
+      "title": "Caption output",
+      "subtitle": "Copy your favourite variation or save it as a campaign draft.",
+      "variant": "Variation",
+      "copy": "Copy",
+      "insightsTitle": "Execution insights",
+      "prompt": "Prompt",
+      "emptyState": "No caption yet. Start by filling the brief on the left."
+    },
+    "presets": {
+      "title": "Strategy presets",
+      "subtitle": "Kickstart faster with proven UMKM campaign ideas."
+    },
+    "history": {
+      "title": "Job history",
+      "subtitle": "Track caption jobs executed through n8n.",
+      "viewWorkflow": "Open workflow",
+      "empty": "No caption jobs yet. Generate your first caption!"
+    },
+    "errors": {
+      "general": "Something went wrong: {message}",
+      "emptyBrief": "Brief cannot be empty."
+    }
   }
 }

--- a/apps/web/src/messages/id.json
+++ b/apps/web/src/messages/id.json
@@ -18,5 +18,76 @@
     "welcome": "Selamat datang kembali",
     "upload": "Unggah foto produk Anda",
     "recentJobs": "Riwayat Job AI"
+  },
+  "captionAi": {
+    "title": "Caption AI profesional",
+    "subtitle": "Bangun caption untuk kampanye omnichannel dengan kontrol tone, CTA, dan hashtag yang presisi. Hubungkan langsung ke workflow n8n untuk proses kreatif yang konsisten.",
+    "capabilities": {
+      "pipelines": "Workflow n8n otomatis dengan callback aman",
+      "templates": "Preset kampanye F&B yang siap pakai",
+      "custom": "Kustomisasi tone, CTA, dan hashtag mendalam"
+    },
+    "form": {
+      "title": "Atur strategi caption",
+      "subtitle": "Detailkan kampanye Anda agar generator AI kami dapat menyusun caption yang relevan untuk audiens brand.",
+      "platform": "Platform",
+      "tone": "Tone komunikasi",
+      "language": "Bahasa konten",
+      "length": "Panjang caption",
+      "variationLabel": "Jumlah variasi",
+      "variations": "{count} variasi",
+      "variationHint": "Maksimal 5 variasi per request",
+      "characters": "{range} karakter",
+      "brief": "Creative brief",
+      "audience": "Audiens utama",
+      "brandVoice": "Suara brand",
+      "keywords": "Keyword utama",
+      "competitorAngles": "Angle kompetitor",
+      "includeHashtags": "Sertakan hashtag",
+      "includeHashtagsHint": "Generator akan membuat hashtag relevan atau gunakan kustom",
+      "includeCTA": "Aktifkan CTA",
+      "includeCTAHint": "Tambahkan ajakan aksi spesifik sesuai kampanye",
+      "includeEmoji": "Emoji dinamis",
+      "includeEmojiHint": "Sesuaikan mood caption dengan emoji",
+      "customHashtags": "Hashtag kustom",
+      "customCTA": "CTA kustom"
+    },
+    "placeholders": {
+      "brief": "Contoh: soft launching menu baru dengan promo bundling pagi",
+      "audience": "Misal: pekerja muda urban yang aktif di Instagram",
+      "brandVoice": "Misal: optimis, hangat, mengutamakan bahan lokal",
+      "keywords": "Pisahkan dengan koma atau baris baru",
+      "competitorAngles": "Cantumkan diferensiasi utama",
+      "hashtags": "Tuliskan hashtag khusus bila diperlukan",
+      "cta": "Misal: Pesan lewat WhatsApp atau klik link di bio"
+    },
+    "actions": {
+      "generate": "Generate caption",
+      "generating": "Menghubungkan ke n8n...",
+      "clear": "Bersihkan brief"
+    },
+    "output": {
+      "title": "Hasil caption",
+      "subtitle": "Salin caption terbaik atau simpan sebagai draft kampanye.",
+      "variant": "Variasi",
+      "copy": "Salin",
+      "insightsTitle": "Insight eksekusi",
+      "prompt": "Prompt",
+      "emptyState": "Belum ada caption. Mulai dengan mengisi brief di kiri."
+    },
+    "presets": {
+      "title": "Preset strategi",
+      "subtitle": "Gunakan inspirasi kampanye populer UMKM untuk mulai lebih cepat."
+    },
+    "history": {
+      "title": "Riwayat job",
+      "subtitle": "Pantau status job caption yang dikirim ke n8n.",
+      "viewWorkflow": "Lihat workflow",
+      "empty": "Belum ada riwayat job caption. Generate caption pertama Anda!"
+    },
+    "errors": {
+      "general": "Terjadi kesalahan: {message}",
+      "emptyBrief": "Brief tidak boleh kosong."
+    }
   }
 }

--- a/apps/web/supabase.sql
+++ b/apps/web/supabase.sql
@@ -77,9 +77,14 @@ create table if not exists public.ai_jobs (
   user_id uuid not null references auth.users(id) on delete cascade,
   job_type text not null,
   status text not null default 'done',
+  result_url text,
+  meta jsonb,
   created_at timestamptz not null default now()
 );
 create index if not exists idx_jobs_user_created on public.ai_jobs(user_id, created_at desc);
+
+alter table public.ai_jobs add column if not exists result_url text;
+alter table public.ai_jobs add column if not exists meta jsonb;
 
 alter table public.profiles enable row level security;
 alter table public.credit_transactions enable row level security;

--- a/n8n/ai-job-workflow.json
+++ b/n8n/ai-job-workflow.json
@@ -4,21 +4,49 @@
     {
       "parameters": {
         "httpMethod": "POST",
-        "path": "ai-job",
+        "path": "ai-caption",
         "options": {
-          "responseData": "{\"status\":\"queued\"}"
+          "responseData": "{\"status\":\"queued\",\"message\":\"Caption request accepted\"}"
         }
       },
       "type": "n8n-nodes-base.webhook",
       "typeVersion": 1,
-      "position": [260, 300],
-      "webhookId": "ai-job"
+      "position": [220, 300],
+      "webhookId": "ai-caption",
+      "name": "Webhook"
+    },
+    {
+      "parameters": {
+        "functionCode": "const incoming = $json;\nconst options = incoming.options ?? {};\nconst prompt = [`You are an Indonesian social media strategist for culinary brands.`,\n  `Platform: ${options.platform}`,\n  `Tone: ${options.tone}`,\n  `Language: ${options.language}`,\n  `Audience: ${options.audience ?? 'General food lovers'}`,\n  `Differentiator: ${options.differentiator ?? 'Highlight artisan ingredients'}`,\n  `Brief: ${options.brief}`\n].join('\n');\nreturn [{\n  jobId: incoming.jobId,\n  callbackUrl: incoming.callbackUrl,\n  options,\n  prompt\n}];"
+      },
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [520, 300],
+      "name": "Compose Prompt"
+    },
+    {
+      "parameters": {
+        "functionCode": "const { options, prompt, jobId, callbackUrl } = $json;\nconst variations = Array.from({ length: options.variations ?? 3 }).map((_, index) => {\n  const base = options.brief || 'Produk baru UMKM Anda';\n  const tone = options.tone ?? 'professional';\n  const mood = options.includeEmoji ? '✨ ' : '';\n  return {\n    id: `${jobId}-${index + 1}`,\n    caption: `${mood}${base} — versi ${index + 1} dengan tone ${tone}. Tekankan bahan lokal dan ajak audiens mencoba sekarang.`,\n    tone\n  };\n});\nconst hashtags = options.includeHashtags\n  ? (options.customHashtags ? options.customHashtags.split(/[,#\n]+/).filter(Boolean).map((tag) => `#${tag.replace(/\s+/g, '')}`) : ['#umkm', '#kulinerkreatif'])\n  : [];\nreturn [{\n  jobId,\n  callbackUrl,\n  options,\n  prompt,\n  variations,\n  hashtags,\n  insights: {\n    hook: 'Mulai dengan pertanyaan reflektif tentang kebutuhan pelanggan.',\n    story: 'Soroti proses produksi handmade dan keunggulan bahan lokal.',\n    closing: options.includeCTA ? (options.customCTA || 'Arahkan audiens ke tautan pemesanan dengan CTA jelas.') : 'Tambahkan CTA ketika siap mengarahkan aksi.'\n  }\n}];"
+      },
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [780, 300],
+      "name": "Generate Variations"
+    },
+    {
+      "parameters": {
+        "functionCode": "const item = $json;\nreturn [{\n  jobId: item.jobId,\n  status: 'succeeded',\n  callbackUrl: item.callbackUrl,\n  resultUrl: null,\n  meta: { ...item.options, prompt: item.prompt },\n  insights: item.insights,\n  variations: item.variations,\n  hashtags: item.hashtags,\n  primary: item.variations?.[0]?.caption ?? null\n}];"
+      },
+      "type": "n8n-nodes-base.function",
+      "typeVersion": 1,
+      "position": [1020, 300],
+      "name": "Format Payload"
     },
     {
       "parameters": {
         "authentication": "none",
         "requestMethod": "POST",
-        "url": "={{$json[\"callbackUrl\"]}}",
+        "url": "={{$json.callbackUrl}}",
         "jsonParameters": true,
         "options": {
           "headers": {
@@ -30,14 +58,58 @@
             ]
           }
         },
-        "bodyParametersJson": "={\n  \"jobId\": $json.jobId,\n  \"status\": \"succeeded\",\n  \"resultUrl\": $json.resultUrl,\n  \"meta\": $json.meta\n}"
+        "bodyParametersJson": "={\n  \"jobId\": $json.jobId,\n  \"status\": $json.status,\n  \"resultUrl\": $json.resultUrl,\n  \"meta\": $json.meta,\n  \"insights\": $json.insights,\n  \"variations\": $json.variations,\n  \"hashtags\": $json.hashtags,\n  \"primary\": $json.primary\n}"
       },
       "type": "n8n-nodes-base.httpRequest",
       "typeVersion": 1,
-      "position": [740, 300]
+      "position": [1280, 300],
+      "name": "Send Callback"
     }
   ],
   "connections": {
-    "UMKM Caption Job Start": {}
+    "Webhook": {
+      "main": [
+        [
+          {
+            "node": "Compose Prompt",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Compose Prompt": {
+      "main": [
+        [
+          {
+            "node": "Generate Variations",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Generate Variations": {
+      "main": [
+        [
+          {
+            "node": "Format Payload",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    },
+    "Format Payload": {
+      "main": [
+        [
+          {
+            "node": "Send Callback",
+            "type": "main",
+            "index": 0
+          }
+        ]
+      ]
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       clsx:
         specifier: ^2.1.0
         version: 2.1.1
+      date-fns:
+        specifier: ^3.6.0
+        version: 3.6.0
       framer-motion:
         specifier: ^11.11.17
         version: 11.18.2(react-dom@19.0.0-rc-66855b96-20241106(react@19.0.0-rc-66855b96-20241106))(react@19.0.0-rc-66855b96-20241106)
@@ -2139,6 +2142,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  date-fns@3.6.0:
+    resolution: {integrity: sha512-fRHTG8g/Gif+kSh50gaGEdToemgfj74aRX3swtiouboip5JDLAyDE9F11nHMIcvOaXeOC6D7SpNhi7uFyB7Uww==}
 
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
@@ -6387,6 +6393,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  date-fns@3.6.0: {}
 
   debug@3.2.7:
     dependencies:


### PR DESCRIPTION
## Summary
- add an authenticated /[locale]/caption-ai page with a configurable caption generator, presets, and job history UI
- provide REST endpoints to queue caption requests through n8n webhooks and handle secure callbacks while recording ai_jobs metadata
- document the integration, extend translations, and refresh the example n8n workflow plus schema to support result tracking

## Testing
- pnpm -C apps/web lint *(fails: Next.js prompts to scaffold ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de9a022ffc832793d9bafd49b2d58b